### PR TITLE
Multiplayer Client Functionality Extension

### DIFF
--- a/prx/rc1/Game.cpp
+++ b/prx/rc1/Game.cpp
@@ -216,7 +216,7 @@ int Game::query_servers_callback(void* data, size_t len, void* extra) {
 
 void Game::query_servers(int directory_id, ServerQueryCallback callback) {
     // client_ = new DirectoryClient("172.104.144.15", 2407);
-    client_ = new DirectoryClient("192.168.5.35", 2407);
+    client_ = new DirectoryClient("172.104.144.15", 2407);
     client_->_connect();
 
     server_query_callback_ = callback;

--- a/prx/rc1/globals.ld
+++ b/prx/rc1/globals.ld
@@ -7,6 +7,7 @@ should_load_destination_planet = 0xa10700;
 current_planet = 0x969C70;
 destination_planet = 0xa10704;
 seen_planets = 0x96ca20;
+galactic_map = 0x96c18c; /* warning! might not be trivial to change around */
 
 player_bolts = 0x969CA0;
 player_pos = 0x969D60;

--- a/prx/rc1/hooks.yml
+++ b/prx/rc1/hooks.yml
@@ -48,6 +48,10 @@ on_item_unlock:
     addr: 0x112e18
     replacedInstr: stdu r1, -0xb0(r1)
 
-on_vendor_thing:
-    addr: 0x4f8d38
-    replacedInstr: ld r2, -0x28(r1)
+on_unlock_planet:
+    addr: 0x112c20
+    replacedInstr: stdu r1, -0xe0(r1)
+
+#on_vendor_thing:
+#    addr: 0x4f8d38
+#    replacedInstr: ld r2, -0x28(r1)

--- a/prx/rc1/hooks.yml
+++ b/prx/rc1/hooks.yml
@@ -47,3 +47,7 @@ goldBoltUpdate:
 on_item_unlock:
     addr: 0x112e18
     replacedInstr: stdu r1, -0xb0(r1)
+
+on_vendor_thing:
+    addr: 0x4f8d38
+    replacedInstr: ld r2, -0x28(r1)

--- a/prx/rc1/multiplayer/DirectoryClient.h
+++ b/prx/rc1/multiplayer/DirectoryClient.h
@@ -6,7 +6,6 @@
 #define RAC1_MULTIPLAYER_DIRECTORYCLIENT_H
 
 #include "Client.h"
-#include "byteswap.h"
 
 class DirectoryClient : public Client {
 public:

--- a/prx/rc1/multiplayer/DirectoryClient.h
+++ b/prx/rc1/multiplayer/DirectoryClient.h
@@ -6,6 +6,7 @@
 #define RAC1_MULTIPLAYER_DIRECTORYCLIENT_H
 
 #include "Client.h"
+#include "byteswap.h"
 
 class DirectoryClient : public Client {
 public:

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -252,7 +252,8 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             break;
         }
         case MP_STATE_TYPE_GIVE_BOLTS: {
-            Logger::debug("Changing bolt count, but we shouldn't be here right now.");
+            Logger::debug("Changing bolt count to: %d", (int)packet->value);
+            Logger::debug("Changing bolt count to: %lu", (unsigned long)packet->value);
             *(int*)0x969CA0 += (int)packet->value;
             break;
         }

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -251,6 +251,14 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             *(int*)(packet->offset) = (int)packet->value;
             break;
         }
+        case MP_STATE_TYPE_SET_BOLTS: {
+            uint32_t value = (uint32_t)packet->value;
+            *(uint32_t*)player_bolts += ((value>>24)&0xff) | // move byte 3 to byte 0
+                                        ((value<<8)&0xff0000) | // move byte 1 to byte 2
+                                        ((value>>8)&0xff00) | // move byte 2 to byte 1
+                                        ((value<<24)&0xff000000); // byte 0 to byte 3
+            break;
+        }
         case MP_STATE_TYPE_GIVE_BOLTS: {
             *(uint32_t*)player_bolts += __bswap_32((uint32_t)packet->value);
             break;

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -252,8 +252,8 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             break;
         }
         case MP_STATE_TYPE_SET_BOLTS: {
-            *(int*)0x969CA0 = 10;
-//            uint32_t value = (uint32_t)packet->value;
+            uint32_t value = (uint32_t)packet->value;
+            Logger::debug("Setting bolt count to %d", value);
 //            *(int*)0x969CA0 += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
 //                                         ((value<<8)&0xff0000) | // move byte 1 to byte 2
 //                                         ((value>>8)&0xff00) | // move byte 2 to byte 1

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -253,10 +253,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
         }
         case MP_STATE_TYPE_SET_BOLTS: {
             uint32_t value = (uint32_t)packet->value;
-            Logger::debug("Setting bolt count to %d", value);
-            Logger::debug("Actually i'm setting it to %x", packet->value);
-            Logger::debug("Bolts address: %x", player_bolts);
-            *(int*)player_bolts += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
+            *(int*)0x969CA0 += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
                                          ((value<<8)&0xff0000) | // move byte 1 to byte 2
                                          ((value>>8)&0xff00) | // move byte 2 to byte 1
                                          ((value<<24)&0xff000000)); // byte 0 to byte 3

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -260,7 +260,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             break;
         }
         case MP_STATE_TYPE_GIVE_BOLTS: {
-            *(uint32_t*)player_bolts += __bswap_32((uint32_t)packet->value);
+            *(uint32_t*)player_bolts += (uint32_t)packet->value;
             break;
         }
         default: {

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -253,6 +253,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
         }
         case MP_STATE_TYPE_SET_BOLTS: {
             uint32_t value = (uint32_t)packet->value;
+            Logger::debug("Setting bolt count to %d", value);
             *(int*)player_bolts += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
                                          ((value<<8)&0xff0000) | // move byte 1 to byte 2
                                          ((value>>8)&0xff00) | // move byte 2 to byte 1
@@ -260,6 +261,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             break;
         }
         case MP_STATE_TYPE_GIVE_BOLTS: {
+            Logger::debug("Changing bolt count, but we shouldn't be here right now.");
             *(uint32_t*)player_bolts += (uint32_t)packet->value;
             break;
         }

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -254,10 +254,10 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
         case MP_STATE_TYPE_SET_BOLTS: {
             uint32_t value = ((MPPacketBolts*)packet)->value;
             Logger::debug("Setting bolt count to %x", value);
-//            *(int*)0x969CA0 += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
-//                                         ((value<<8)&0xff0000) | // move byte 1 to byte 2
-//                                         ((value>>8)&0xff00) | // move byte 2 to byte 1
-//                                         ((value<<24)&0xff000000)); // byte 0 to byte 3
+            *(int*)0x969CA0 += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
+                                         ((value<<8)&0xff0000) | // move byte 1 to byte 2
+                                         ((value>>8)&0xff00) | // move byte 2 to byte 1
+                                         ((value<<24)&0xff000000)); // byte 0 to byte 3
             break;
         }
         case MP_STATE_TYPE_GIVE_BOLTS: {

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -253,10 +253,10 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
         }
         case MP_STATE_TYPE_SET_BOLTS: {
             uint32_t value = (uint32_t)packet->value;
-            *(uint32_t*)player_bolts += ((value>>24)&0xff) | // move byte 3 to byte 0
-                                        ((value<<8)&0xff0000) | // move byte 1 to byte 2
-                                        ((value>>8)&0xff00) | // move byte 2 to byte 1
-                                        ((value<<24)&0xff000000); // byte 0 to byte 3
+            *(int*)player_bolts += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
+                                         ((value<<8)&0xff0000) | // move byte 1 to byte 2
+                                         ((value>>8)&0xff00) | // move byte 2 to byte 1
+                                         ((value<<24)&0xff000000)); // byte 0 to byte 3
             break;
         }
         case MP_STATE_TYPE_GIVE_BOLTS: {

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -204,7 +204,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
 
                 Logger::debug("Printing galactic map entries!");
                 for (int i = 0x96c18c; i < 0x96c1a8; i += 0x4) {
-                    if (packet->offset && *(int*)i == *(int*)0x969C70) *(int*)i = 0; // if the not unlock param is true and the current planet is in the visited list, set it to zero. I intend to figure out whether the pointer will cause issues later.
+                    if (!packet->offset && *(int*)i == *(int*)0x969C70) *(int*)i = 0; // if the not unlock param is true and the current planet is in the visited list, set it to zero. I intend to figure out whether the pointer will cause issues later.
                     Logger::debug("Current galactic_map[%d] = 0x%x", i, *(int*)i);
                 }
                 Logger::debug("");

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -254,7 +254,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
         case MP_STATE_TYPE_SET_BOLTS: {
             uint32_t value = (uint32_t)packet->value;
             Logger::debug("Setting bolt count to %d", value);
-            Logger::debug("Actually i'm setting it to %d", packet->value);
+            Logger::debug("Actually i'm setting it to %x", packet->value);
             *(int*)player_bolts += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
                                          ((value<<8)&0xff0000) | // move byte 1 to byte 2
                                          ((value>>8)&0xff00) | // move byte 2 to byte 1

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -251,6 +251,10 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             *(int*)(packet->offset) = (int)packet->value;
             break;
         }
+        case MP_STATE_TYPE_GIVE_BOLTS: {
+            *(int*)player_bolts += (int)packet->value;
+            break;
+        }
         default: {
             Logger::error("Server asked us to set unknown state type %d", packet->state_type);
         }

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -204,7 +204,8 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
 
                 Logger::debug("Printing galactic map entries!");
                 for (int i = 0x96c18c; i < 0x96c1a8; i += 0x4) {
-                    Logger::debug("Current galactic_map[%d] = %x", i, *(int*)i);
+                    if (packet->offset && i == *(int*)0x969C70) *(int*)i = 0; // if the not unlock param is true and the current planet is in the visited list, set it to zero. I intend to figure out whether the pointer will cause issues later.
+                    Logger::debug("Current galactic_map[%d] = 0x%x", i, *(int*)i);
                 }
                 Logger::debug("");
                 *(int*)0xa10700 = 1;

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -204,7 +204,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
 
                 Logger::debug("Printing galactic map entries!");
                 for (int i = 0x96c18c; i < 0x96c1a8; i += 0x4) {
-                    if (packet->offset && i == *(int*)0x969C70) *(int*)i = 0; // if the not unlock param is true and the current planet is in the visited list, set it to zero. I intend to figure out whether the pointer will cause issues later.
+                    if (packet->offset && *(int*)i == *(int*)0x969C70) *(int*)i = 0; // if the not unlock param is true and the current planet is in the visited list, set it to zero. I intend to figure out whether the pointer will cause issues later.
                     Logger::debug("Current galactic_map[%d] = 0x%x", i, *(int*)i);
                 }
                 Logger::debug("");

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -206,10 +206,10 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
                 for (int i = 0x96c18c; i < 0x96c1a8; i += 0x4) {
                     Logger::debug("Current galactic_map[%d] = %x", i, *(int*)i);
                 }
+                Logger::debug("");
                 *(int*)0xa10700 = 1;
                 *(int*)0xa10704 = (int)packet->value;
                 *(int*)0x969c70 = (int)packet->value;
-                Logger:debug("");
             }
 
             break;

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -253,7 +253,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
         }
         case MP_STATE_TYPE_SET_BOLTS: {
             uint32_t value = ((MPPacketBolts*)packet)->value;
-            Logger::debug("Setting bolt count to %d", value);
+            Logger::debug("Setting bolt count to %x", value);
 //            *(int*)0x969CA0 += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
 //                                         ((value<<8)&0xff0000) | // move byte 1 to byte 2
 //                                         ((value>>8)&0xff00) | // move byte 2 to byte 1

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -255,6 +255,11 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             *(uint32_t*)0x969CA0 += packet->value;
             break;
         }
+        case MP_STATE_TYPE_UNLOCK_PLANET: {
+            int planet = (int)(packet->value);
+            planetUnlockedByServer = 1;
+            unlock_planet(planet);
+        }
         default: {
             Logger::error("Server asked us to set unknown state type %d", packet->state_type);
         }

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -201,6 +201,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
                 Logger::info("Going to planet %d", (int)packet->value);
                 seen_planets[0] = 1;
                 seen_planets[packet->value] = 1;
+                Logger::debug("Current galactic_map = %x", *(int*)0x96c18c);
                 *(int*)0xa10700 = 1;
                 *(int*)0xa10704 = (int)packet->value;
                 *(int*)0x969c70 = (int)packet->value;

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -216,13 +216,16 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             break;
         }
         case MP_STATE_TYPE_ITEM: {
-            u16 give = (u16)(packet->value  >> 16);
+            u8 give = (u8)(packet->value  >> 16);
             u16 item = (u16)(packet->value & 0xFFFF);
 
-            if (give) {
-                itemGivenByServer = 1;
-                unlock_item(item, 0);
-            }
+            itemGivenByServer = 1;
+            unlock_item(item, give);
+
+//            if (give) {
+//                itemGivenByServer = 1;
+//                unlock_item(item, 0);
+//            }
 
             break;
         }

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -252,7 +252,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             break;
         }
         case MP_STATE_TYPE_GIVE_BOLTS: {
-            *(int*)player_bolts += (int)packet->value;
+            *(uint32_t*)player_bolts += __bswap_32((uint32_t)packet->value);
             break;
         }
         default: {

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -213,6 +213,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             u16 item = (u16)(packet->value & 0xFFFF);
 
             if (give) {
+                itemGivenByServer = 1;
                 unlock_item(item, 0);
             }
 

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -201,10 +201,15 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
                 Logger::info("Going to planet %d", (int)packet->value);
                 seen_planets[0] = 1;
                 seen_planets[packet->value] = 1;
-                Logger::debug("Current galactic_map = %x", *(int*)0x96c18c);
+
+                Logger::debug("Printing galactic map entries!");
+                for (int i = 0x96c18c; i < 0x96c1a8; i += 0x4) {
+                    Logger::debug("Current galactic_map[%d] = %x", i, *(int*)i);
+                }
                 *(int*)0xa10700 = 1;
                 *(int*)0xa10704 = (int)packet->value;
                 *(int*)0x969c70 = (int)packet->value;
+                Logger:debug("");
             }
 
             break;

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -200,7 +200,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
                 ratchet_moby == nullptr) {
                 Logger::info("Going to planet %d", (int)packet->value);
                 seen_planets[0] = 1;
-                if (!packet->offset) seen_planets[packet->value] = 1;
+                if (packet->offset) seen_planets[packet->value] = 1;
 
                 Logger::debug("Printing galactic map entries!");
                 for (int i = 0x96c18c; i < 0x96c1a8; i += 0x4) {

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -201,9 +201,9 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
                 Logger::info("Going to planet %d", (int)packet->value);
                 seen_planets[0] = 1;
                 seen_planets[packet->value] = 1;
-                *(int*)0xa10700 = 1;
                 *(int*)0xa10704 = (int)packet->value;
                 *(int*)0x969c70 = (int)packet->value;
+                *(int*)0xa10700 = 1;
             }
 
             break;

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -200,14 +200,14 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
                 ratchet_moby == nullptr) {
                 Logger::info("Going to planet %d", (int)packet->value);
                 seen_planets[0] = 1;
-                if (packet->offset) seen_planets[packet->value] = 1;
+                seen_planets[packet->value] = 1;
 
-                Logger::debug("Printing galactic map entries!");
-                for (int i = 0x96c18c; i < 0x96c1a8; i += 0x4) {
-                    if (!packet->offset && *(int*)i == *(int*)0x969C70) *(int*)i = 0; // if the not unlock param is true and the current planet is in the visited list, set it to zero. I intend to figure out whether the pointer will cause issues later.
-                    Logger::debug("Current galactic_map[%d] = 0x%x", i, *(int*)i);
-                }
-                Logger::debug("");
+//                Logger::debug("Printing galactic map entries!");
+//                for (int i = 0x96c18c; i < 0x96c1a8; i += 0x4) {
+//                    if (!packet->offset && *(int*)i == *(int*)0x969C70) *(int*)i = 0; // if the not unlock param is true and the current planet is in the visited list, set it to zero. I intend to figure out whether the pointer will cause issues later.
+//                    Logger::debug("Current galactic_map[%d] = 0x%x", i, *(int*)i);
+//                }
+//                Logger::debug("");
                 *(int*)0xa10700 = 1;
                 *(int*)0xa10704 = (int)packet->value;
                 *(int*)0x969c70 = (int)packet->value;

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -251,18 +251,9 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             *(int*)(packet->offset) = (int)packet->value;
             break;
         }
-        case MP_STATE_TYPE_SET_BOLTS: {
-            uint32_t value = ((MPPacketBolts*)packet)->value;
-            Logger::debug("Setting bolt count to %x", value);
-            *(int*)0x969CA0 += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
-                                         ((value<<8)&0xff0000) | // move byte 1 to byte 2
-                                         ((value>>8)&0xff00) | // move byte 2 to byte 1
-                                         ((value<<24)&0xff000000)); // byte 0 to byte 3
-            break;
-        }
         case MP_STATE_TYPE_GIVE_BOLTS: {
             Logger::debug("Changing bolt count, but we shouldn't be here right now.");
-            *(uint32_t*)player_bolts += (uint32_t)packet->value;
+            *(int*)0x969CA0 += (int)packet->value;
             break;
         }
         default: {

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -200,7 +200,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
                 ratchet_moby == nullptr) {
                 Logger::info("Going to planet %d", (int)packet->value);
                 seen_planets[0] = 1;
-                seen_planets[packet->value] = 1;
+                if ((int)packet->offset) seen_planets[packet->value] = 1;
                 *(int*)0xa10700 = 1;
                 *(int*)0xa10704 = (int)packet->value;
                 *(int*)0x969c70 = (int)packet->value;

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -252,9 +252,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             break;
         }
         case MP_STATE_TYPE_GIVE_BOLTS: {
-            Logger::debug("Changing bolt count to: %d", (int)packet->value);
-            Logger::debug("Changing bolt count to: %lu", (unsigned long)packet->value);
-            *(int*)0x969CA0 += (int)packet->value;
+            *(uint32_t*)0x969CA0 += packet->value;
             break;
         }
         default: {

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -252,11 +252,12 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             break;
         }
         case MP_STATE_TYPE_SET_BOLTS: {
-            uint32_t value = (uint32_t)packet->value;
-            *(int*)0x969CA0 += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
-                                         ((value<<8)&0xff0000) | // move byte 1 to byte 2
-                                         ((value>>8)&0xff00) | // move byte 2 to byte 1
-                                         ((value<<24)&0xff000000)); // byte 0 to byte 3
+            *(int*)0x969CA0 = 10;
+//            uint32_t value = (uint32_t)packet->value;
+//            *(int*)0x969CA0 += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
+//                                         ((value<<8)&0xff0000) | // move byte 1 to byte 2
+//                                         ((value>>8)&0xff00) | // move byte 2 to byte 1
+//                                         ((value<<24)&0xff000000)); // byte 0 to byte 3
             break;
         }
         case MP_STATE_TYPE_GIVE_BOLTS: {

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -200,7 +200,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
                 ratchet_moby == nullptr) {
                 Logger::info("Going to planet %d", (int)packet->value);
                 seen_planets[0] = 1;
-                seen_planets[packet->value] = 1;
+                if (!packet->offset) seen_planets[packet->value] = 1;
 
                 Logger::debug("Printing galactic map entries!");
                 for (int i = 0x96c18c; i < 0x96c1a8; i += 0x4) {

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -201,9 +201,9 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
                 Logger::info("Going to planet %d", (int)packet->value);
                 seen_planets[0] = 1;
                 seen_planets[packet->value] = 1;
+                *(int*)0xa10700 = 1;
                 *(int*)0xa10704 = (int)packet->value;
                 *(int*)0x969c70 = (int)packet->value;
-                *(int*)0xa10700 = 1;
             }
 
             break;

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -255,6 +255,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             uint32_t value = (uint32_t)packet->value;
             Logger::debug("Setting bolt count to %d", value);
             Logger::debug("Actually i'm setting it to %x", packet->value);
+            Logger::debug("Bolts address: %x", player_bolts);
             *(int*)player_bolts += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
                                          ((value<<8)&0xff0000) | // move byte 1 to byte 2
                                          ((value>>8)&0xff00) | // move byte 2 to byte 1

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -254,6 +254,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
         case MP_STATE_TYPE_SET_BOLTS: {
             uint32_t value = (uint32_t)packet->value;
             Logger::debug("Setting bolt count to %d", value);
+            Logger::debug("Actually i'm setting it to %d", packet->value);
             *(int*)player_bolts += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
                                          ((value<<8)&0xff0000) | // move byte 1 to byte 2
                                          ((value>>8)&0xff00) | // move byte 2 to byte 1

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -200,7 +200,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
                 ratchet_moby == nullptr) {
                 Logger::info("Going to planet %d", (int)packet->value);
                 seen_planets[0] = 1;
-                if ((int)packet->offset) seen_planets[packet->value] = 1;
+                seen_planets[packet->value] = 1;
                 *(int*)0xa10700 = 1;
                 *(int*)0xa10704 = (int)packet->value;
                 *(int*)0x969c70 = (int)packet->value;

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -252,7 +252,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             break;
         }
         case MP_STATE_TYPE_SET_BOLTS: {
-            uint32_t value = (uint32_t)packet->value;
+            uint32_t value = (MPPacketBolts)packet->value;
             Logger::debug("Setting bolt count to %d", value);
 //            *(int*)0x969CA0 += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
 //                                         ((value<<8)&0xff0000) | // move byte 1 to byte 2

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -252,7 +252,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             break;
         }
         case MP_STATE_TYPE_SET_BOLTS: {
-            uint32_t value = (MPPacketBolts)packet->value;
+            uint32_t value = ((MPPacketBolts*)packet)->value;
             Logger::debug("Setting bolt count to %d", value);
 //            *(int*)0x969CA0 += (int)(((value>>24)&0xff) | // move byte 3 to byte 0
 //                                         ((value<<8)&0xff0000) | // move byte 1 to byte 2

--- a/prx/rc1/multiplayer/Packet.cpp
+++ b/prx/rc1/multiplayer/Packet.cpp
@@ -187,7 +187,7 @@ Packet* Packet::make_collected_gold_bolt_packet(int bolt_number) {
     return packet;
 }
 
-Packet* Packet::make_unlock_item_packet(int* item_id) {
+Packet* Packet::make_unlock_item_packet(int item_id) {
     Packet* packet = new Packet(sizeof(MPPacketSetState));
     packet->header->type = MP_PACKET_SET_STATE;
     packet->header->size = sizeof(MPPacketSetState);

--- a/prx/rc1/multiplayer/Packet.cpp
+++ b/prx/rc1/multiplayer/Packet.cpp
@@ -189,7 +189,7 @@ Packet* Packet::make_collected_gold_bolt_packet(int bolt_number) {
 
 Packet* Packet::make_unlock_item_packet(int item_id) {
     Packet* packet = new Packet(sizeof(MPPacketSetState));
-    packet->header->type = MP_PACKET_SET_STATE;
+//    packet->header->type = MP_PACKET_SET_STATE;
 //    packet->header->size = sizeof(MPPacketSetState);
 
 //    MPPacketSetState* body = (MPPacketSetState*)packet->body;

--- a/prx/rc1/multiplayer/Packet.cpp
+++ b/prx/rc1/multiplayer/Packet.cpp
@@ -200,7 +200,7 @@ Packet* Packet::make_unlock_item_packet(int item_id) {
     return packet;
 }
 
-Packet* Packet::make_unlock_item_packet(int planet) {
+Packet* Packet::make_unlock_planet_packet(int planet) {
     Packet* packet = new Packet(sizeof(MPPacketSetState));
     packet->header->type = MP_PACKET_SET_STATE;
     packet->header->size = sizeof(MPPacketSetState);

--- a/prx/rc1/multiplayer/Packet.cpp
+++ b/prx/rc1/multiplayer/Packet.cpp
@@ -199,3 +199,16 @@ Packet* Packet::make_unlock_item_packet(int item_id) {
 
     return packet;
 }
+
+Packet* Packet::make_unlock_item_packet(int planet) {
+    Packet* packet = new Packet(sizeof(MPPacketSetState));
+    packet->header->type = MP_PACKET_SET_STATE;
+    packet->header->size = sizeof(MPPacketSetState);
+
+    MPPacketSetState* body = (MPPacketSetState*)packet->body;
+    body->state_type = MP_STATE_TYPE_UNLOCK_PLANET;
+    body->value = planet;
+    body->offset = 0;
+
+    return packet;
+}

--- a/prx/rc1/multiplayer/Packet.cpp
+++ b/prx/rc1/multiplayer/Packet.cpp
@@ -190,7 +190,7 @@ Packet* Packet::make_collected_gold_bolt_packet(int bolt_number) {
 Packet* Packet::make_unlock_item_packet(int item_id) {
     Packet* packet = new Packet(sizeof(MPPacketSetState));
     packet->header->type = MP_PACKET_SET_STATE;
-    packet->header->size = sizeof(MPPacketSetState);
+//    packet->header->size = sizeof(MPPacketSetState);
 
 //    MPPacketSetState* body = (MPPacketSetState*)packet->body;
 //    body->state_type = MP_STATE_TYPE_UNLOCK_ITEM;

--- a/prx/rc1/multiplayer/Packet.cpp
+++ b/prx/rc1/multiplayer/Packet.cpp
@@ -192,10 +192,10 @@ Packet* Packet::make_unlock_item_packet(int item_id) {
     packet->header->type = MP_PACKET_SET_STATE;
     packet->header->size = sizeof(MPPacketSetState);
 
-    MPPacketSetState* body = (MPPacketSetState*)packet->body;
-    body->state_type = MP_STATE_TYPE_UNLOCK_ITEM;
-    body->value = item_id;
-    body->offset = 0;
+//    MPPacketSetState* body = (MPPacketSetState*)packet->body;
+//    body->state_type = MP_STATE_TYPE_UNLOCK_ITEM;
+//    body->value = item_id;
+//    body->offset = 0;
 
     return packet;
 }

--- a/prx/rc1/multiplayer/Packet.cpp
+++ b/prx/rc1/multiplayer/Packet.cpp
@@ -195,6 +195,7 @@ Packet* Packet::make_unlock_item_packet(int item_id) {
     MPPacketSetState* body = (MPPacketSetState*)packet->body;
     body->state_type = MP_STATE_TYPE_UNLOCK_ITEM;
     body->value = item_id;
+    body->offset = 0;
 
     return packet;
 }

--- a/prx/rc1/multiplayer/Packet.cpp
+++ b/prx/rc1/multiplayer/Packet.cpp
@@ -189,13 +189,13 @@ Packet* Packet::make_collected_gold_bolt_packet(int bolt_number) {
 
 Packet* Packet::make_unlock_item_packet(int item_id) {
     Packet* packet = new Packet(sizeof(MPPacketSetState));
-//    packet->header->type = MP_PACKET_SET_STATE;
-//    packet->header->size = sizeof(MPPacketSetState);
+    packet->header->type = MP_PACKET_SET_STATE;
+    packet->header->size = sizeof(MPPacketSetState);
 
-//    MPPacketSetState* body = (MPPacketSetState*)packet->body;
-//    body->state_type = MP_STATE_TYPE_UNLOCK_ITEM;
-//    body->value = item_id;
-//    body->offset = 0;
+    MPPacketSetState* body = (MPPacketSetState*)packet->body;
+    body->state_type = MP_STATE_TYPE_UNLOCK_ITEM;
+    body->value = item_id;
+    body->offset = 0;
 
     return packet;
 }

--- a/prx/rc1/multiplayer/Packet.cpp
+++ b/prx/rc1/multiplayer/Packet.cpp
@@ -187,7 +187,7 @@ Packet* Packet::make_collected_gold_bolt_packet(int bolt_number) {
     return packet;
 }
 
-Packet* Packet::make_unlock_item_packet(int item_id) {
+Packet* Packet::make_unlock_item_packet(int* item_id) {
     Packet* packet = new Packet(sizeof(MPPacketSetState));
     packet->header->type = MP_PACKET_SET_STATE;
     packet->header->size = sizeof(MPPacketSetState);

--- a/prx/rc1/multiplayer/Packet.h
+++ b/prx/rc1/multiplayer/Packet.h
@@ -170,6 +170,7 @@ typedef struct {
 #define MP_STATE_TYPE_ARBITRARY 11
 #define MP_STATE_TYPE_UNLOCK_ITEM 12
 #define MP_STATE_TYPE_GIVE_BOLTS 13
+#define MP_STATE_TYPE_UNLOCK_PLANET 14
 
 typedef struct {
     u32 state_type;
@@ -252,6 +253,7 @@ struct Packet {
     static Packet* make_game_state_changed_packet(GameState state);
     static Packet* make_collected_gold_bolt_packet(int bolt_number);
     static Packet* make_unlock_item_packet(int item_id);
+    static Packet* make_unlock_planet_packet(int planet);
 };
 
 #endif

--- a/prx/rc1/multiplayer/Packet.h
+++ b/prx/rc1/multiplayer/Packet.h
@@ -169,7 +169,8 @@ typedef struct {
 #define MP_STATE_TYPE_PLAYER_INPUT 10
 #define MP_STATE_TYPE_ARBITRARY 11
 #define MP_STATE_TYPE_UNLOCK_ITEM 12
-#define MP_STATE_TYPE_GIVE_BOLTS 13
+#define MP_STATE_TYPE_SET_BOLTS 13
+#define MP_STATE_TYPE_GIVE_BOLTS 14
 
 typedef struct {
     u32 state_type;
@@ -224,6 +225,10 @@ typedef struct {
     uint32_t duration;
     char message[0x50];
 } MPPacketToastMessage;
+
+typedef struct {
+    uint32_t value;
+} MPPacketBolts;
 
 #pragma pack(pop)
 

--- a/prx/rc1/multiplayer/Packet.h
+++ b/prx/rc1/multiplayer/Packet.h
@@ -169,6 +169,7 @@ typedef struct {
 #define MP_STATE_TYPE_PLAYER_INPUT 10
 #define MP_STATE_TYPE_ARBITRARY 11
 #define MP_STATE_TYPE_UNLOCK_ITEM 12
+#define MP_STATE_TYPE_GIVE_BOLTS 13
 
 typedef struct {
     u32 state_type;

--- a/prx/rc1/multiplayer/Packet.h
+++ b/prx/rc1/multiplayer/Packet.h
@@ -246,7 +246,7 @@ struct Packet {
     static Packet* make_player_respawned_packet();
     static Packet* make_game_state_changed_packet(GameState state);
     static Packet* make_collected_gold_bolt_packet(int bolt_number);
-    static Packet* make_unlock_item_packet(int item_id);
+    static Packet* make_unlock_item_packet(int* item_id);
 };
 
 #endif

--- a/prx/rc1/multiplayer/Packet.h
+++ b/prx/rc1/multiplayer/Packet.h
@@ -169,8 +169,7 @@ typedef struct {
 #define MP_STATE_TYPE_PLAYER_INPUT 10
 #define MP_STATE_TYPE_ARBITRARY 11
 #define MP_STATE_TYPE_UNLOCK_ITEM 12
-#define MP_STATE_TYPE_SET_BOLTS 13
-#define MP_STATE_TYPE_GIVE_BOLTS 14
+#define MP_STATE_TYPE_GIVE_BOLTS 13
 
 typedef struct {
     u32 state_type;

--- a/prx/rc1/multiplayer/Packet.h
+++ b/prx/rc1/multiplayer/Packet.h
@@ -246,7 +246,7 @@ struct Packet {
     static Packet* make_player_respawned_packet();
     static Packet* make_game_state_changed_packet(GameState state);
     static Packet* make_collected_gold_bolt_packet(int bolt_number);
-    static Packet* make_unlock_item_packet(int* item_id);
+    static Packet* make_unlock_item_packet(int item_id);
 };
 
 #endif

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -181,6 +181,12 @@ void on_item_unlock_hook(int item_id) {
     }
 }
 
+SHK_HOOK(void, on_vendor_thingy, int);
+void on_vendor_thingy_hook(int item) {
+    Logger::debug("Vendor thingy hit with item: %d", item);
+    SHK_CALL_HOOK(on_vendor_thingy, item);
+}
+
 void rc1_init() {
     MULTI_LOG("Multiplayer initializing.\n");
 
@@ -199,6 +205,7 @@ void rc1_init() {
     SHK_BIND_HOOK(cellGameContentPermit, cellGameContentPermitHook);
     SHK_BIND_HOOK(goldBoltUpdate, goldBoltUpdateHook);
     SHK_BIND_HOOK(on_item_unlock, on_item_unlock_hook);
+    SHK_BIND_HOOK(on_vendor_thingy, on_vendor_thingy_hook);
 
     MULTI_LOG("Bound hooks\n");
 }

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -165,7 +165,7 @@ void goldBoltUpdateHook(Moby* moby) {
 }
 
 SHK_HOOK(void, on_item_unlock, int);
-void on_item_unlock_hook(int* item_id) {
+void on_item_unlock_hook(int item_id) {
     Client* client = Game::shared().client();
     if (client != nullptr) {
         Packet* packet = Packet::make_unlock_item_packet(item_id);

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -18,6 +18,7 @@ void game_tick() {
 }
 
 int itemGivenByServer = 0;
+int planetUnlockedByServer = 0;
 
 SHK_HOOK(void, game_loop_start);
 void game_loop_start_hook() {
@@ -189,16 +190,17 @@ void on_item_unlock_hook(int item_id) {
 
 SHK_HOOK(void, on_unlock_planet, int);
 void on_unlock_planet_hook(int planet) {
-    Logger::debug("Unlock planet: %x", planet);
-
-    Client *client = Game::shared().client();
-    if (client != nullptr) {
-        Packet *packet = Packet::make_unlock_planet_packet(planet);
-        client->make_ack(packet, nullptr);
-        client->send(packet);
+    if (planetUnlockedByServer) {
+        planetUnlockedByServer = 0;
+        SHK_CALL_HOOK(on_unlock_planet, planet);
+    } else {
+        Client *client = Game::shared().client();
+        if (client != nullptr) {
+            Packet *packet = Packet::make_unlock_planet_packet(planet);
+            client->make_ack(packet, nullptr);
+            client->send(packet);
+        }
     }
-
-    SHK_CALL_HOOK(on_unlock_planet, planet);
 }
 
 void rc1_init() {

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -166,6 +166,12 @@ void goldBoltUpdateHook(Moby* moby) {
 
 SHK_HOOK(void, on_item_unlock, int*);
 void on_item_unlock_hook(int* item_id) {
+    Client* client = Game::shared().client();
+    if (client != nullptr) {
+        Packet* packet = Packet::make_unlock_item_packet(*item_id);
+        client->make_ack(packet, nullptr);
+        client->send(packet);
+    }
 //    if (Game::shared().client()) {
 //        Game::shared().client()->send(Packet::make_unlock_item_packet(*item_id));
 //    }

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -113,7 +113,7 @@ SHK_HOOK(int, cellGameContentPermit, char*, char*);
 int cellGameContentPermitHook(char* contentInfoPath, char* usrdirPath) {
     MULTI_LOG("contentInfoPath: %p, usrdirPath: %p\n", contentInfoPath, usrdirPath);
     // Manually copying the string
-    const char* src = "/dev_bdvd/PS3_GAME"; 
+    const char* src = "/dev_bdvd/PS3_GAME";
     while (*src) {
         *contentInfoPath = *src;
         contentInfoPath++;
@@ -146,9 +146,10 @@ void on_item_unlock_hook(int* item_id) {
     if (Game::shared().client()) {
             Game::shared().client()->send(Packet::make_unlock_item_packet(*item_id));
         }
-    if (*item_id == 0xa) { // bomb glove
-        SHK_CALL_HOOK(on_item_unlock, item_id); // probably not send this by default and do it later instead
-    }
+//    if (*item_id == 0xa) { // bomb glove
+//        SHK_CALL_HOOK(on_item_unlock, item_id); // probably not send this by default and do it later instead
+//    }
+    SHK_CALL_HOOK(on_item_unlock, item_id); // probably not send this by default and do it later instead
 }
 
 void rc1_init() {

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -167,12 +167,12 @@ void goldBoltUpdateHook(Moby* moby) {
 SHK_HOOK(void, on_item_unlock, int*);
 void on_item_unlock_hook(int* item_id) {
     if (Game::shared().client()) {
-            Game::shared().client()->send(Packet::make_unlock_item_packet(*item_id));
-        }
+        Game::shared().client()->send(Packet::make_unlock_item_packet(*item_id));
+    }
+    SHK_CALL_HOOK(on_item_unlock, item_id);
 //    if (*item_id == 0xa) { // bomb glove
-//        SHK_CALL_HOOK(on_item_unlock, item_id); // probably not send this by default and do it later instead
+//        SHK_CALL_HOOK(on_item_unlock, item_id);
 //    }
-    SHK_CALL_HOOK(on_item_unlock, item_id); // probably not send this by default and do it later instead
 }
 
 void rc1_init() {

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -164,7 +164,7 @@ void goldBoltUpdateHook(Moby* moby) {
     ((GoldBolt*)moby)->update();
 }
 
-SHK_HOOK(void, on_item_unlock, int*);
+SHK_HOOK(void, on_item_unlock, int);
 void on_item_unlock_hook(int* item_id) {
     Client* client = Game::shared().client();
     if (client != nullptr) {

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -166,16 +166,17 @@ void goldBoltUpdateHook(Moby* moby) {
 
 SHK_HOOK(void, on_item_unlock, int);
 void on_item_unlock_hook(int item_id) {
-    Client* client = Game::shared().client();
-    if (client != nullptr) {
-        Packet* packet = Packet::make_unlock_item_packet(item_id);
-        client->make_ack(packet, nullptr);
-        client->send(packet);
+    if (itemGivenByServer) {
+        itemGivenByServer = 0;
+        SHK_CALL_HOOK(on_item_unlock, item_id);
+    } else {
+        Client *client = Game::shared().client();
+        if (client != nullptr) {
+            Packet *packet = Packet::make_unlock_item_packet(item_id);
+            client->make_ack(packet, nullptr);
+            client->send(packet);
+        }
     }
-//    SHK_CALL_HOOK(on_item_unlock, item_id);
-//    if (*item_id == 0xa) { // bomb glove
-//        SHK_CALL_HOOK(on_item_unlock, item_id);
-//    }
 }
 
 void rc1_init() {

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -169,8 +169,8 @@ void on_item_unlock_hook(int* item_id) {
     Client* client = Game::shared().client();
     if (client != nullptr) {
         Packet* packet = Packet::make_unlock_item_packet(*item_id);
-        client->make_ack(packet, nullptr);
-        client->send(packet);
+//        client->make_ack(packet, nullptr);
+//        client->send(packet);
     }
 //    if (Game::shared().client()) {
 //        Game::shared().client()->send(Packet::make_unlock_item_packet(*item_id));

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -181,10 +181,24 @@ void on_item_unlock_hook(int item_id) {
     }
 }
 
-SHK_HOOK(void, on_vendor_thing, int);
-void on_vendor_thing_hook(int item) {
-    Logger::debug("Vendor thingy hit with item: %d", item);
-    SHK_CALL_HOOK(on_vendor_thing, item);
+//SHK_HOOK(void, on_vendor_thing, int);
+//void on_vendor_thing_hook(int item) {
+//    Logger::debug("Vendor thingy hit with item: %d", item);
+//    SHK_CALL_HOOK(on_vendor_thing, item);
+//}
+
+SHK_HOOK(void, on_unlock_planet, int);
+void on_unlock_planet_hook(int planet) {
+    Logger::debug("Unlock planet: %x", planet);
+
+    Client *client = Game::shared().client();
+    if (client != nullptr) {
+        Packet *packet = Packet::make_unlock_planet_packet(planet);
+        client->make_ack(packet, nullptr);
+        client->send(packet);
+    }
+
+    SHK_CALL_HOOK(on_unlock_planet, planet);
 }
 
 void rc1_init() {
@@ -205,7 +219,8 @@ void rc1_init() {
     SHK_BIND_HOOK(cellGameContentPermit, cellGameContentPermitHook);
     SHK_BIND_HOOK(goldBoltUpdate, goldBoltUpdateHook);
     SHK_BIND_HOOK(on_item_unlock, on_item_unlock_hook);
-    SHK_BIND_HOOK(on_vendor_thing, on_vendor_thing_hook);
+//    SHK_BIND_HOOK(on_vendor_thing, on_vendor_thing_hook);
+    SHK_BIND_HOOK(on_unlock_planet, on_unlock_planet_hook);
 
     MULTI_LOG("Bound hooks\n");
 }

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -17,6 +17,8 @@ void game_tick() {
     _c_game_tick();
 }
 
+int itemGivenByServer = 0;
+
 SHK_HOOK(void, game_loop_start);
 void game_loop_start_hook() {
     if (current_planet != 0 || ratchet_moby != 0) {

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -167,11 +167,11 @@ void goldBoltUpdateHook(Moby* moby) {
 SHK_HOOK(void, on_item_unlock, int*);
 void on_item_unlock_hook(int* item_id) {
     Client* client = Game::shared().client();
-//    if (client != nullptr) {
+    if (client != nullptr) {
 //        Packet* packet = Packet::make_unlock_item_packet(*item_id);
-////        client->make_ack(packet, nullptr);
-////        client->send(packet);
-//    }
+//        client->make_ack(packet, nullptr);
+//        client->send(packet);
+    }
 //    if (Game::shared().client()) {
 //        Game::shared().client()->send(Packet::make_unlock_item_packet(*item_id));
 //    }

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -164,16 +164,16 @@ void goldBoltUpdateHook(Moby* moby) {
     ((GoldBolt*)moby)->update();
 }
 
-SHK_HOOK(void, on_item_unlock, int*);
-void on_item_unlock_hook(int* item_id) {
-    if (Game::shared().client()) {
-        Game::shared().client()->send(Packet::make_unlock_item_packet(*item_id));
-    }
-    SHK_CALL_HOOK(on_item_unlock, item_id);
-//    if (*item_id == 0xa) { // bomb glove
-//        SHK_CALL_HOOK(on_item_unlock, item_id);
+//SHK_HOOK(void, on_item_unlock, int*);
+//void on_item_unlock_hook(int* item_id) {
+//    if (Game::shared().client()) {
+//        Game::shared().client()->send(Packet::make_unlock_item_packet(*item_id));
 //    }
-}
+//    SHK_CALL_HOOK(on_item_unlock, item_id);
+////    if (*item_id == 0xa) { // bomb glove
+////        SHK_CALL_HOOK(on_item_unlock, item_id);
+////    }
+//}
 
 void rc1_init() {
     MULTI_LOG("Multiplayer initializing.\n");
@@ -192,7 +192,7 @@ void rc1_init() {
     SHK_BIND_HOOK(cellGameBootCheck, cellGameBootCheckHook);
     SHK_BIND_HOOK(cellGameContentPermit, cellGameContentPermitHook);
     SHK_BIND_HOOK(goldBoltUpdate, goldBoltUpdateHook);
-    SHK_BIND_HOOK(on_item_unlock, on_item_unlock_hook);
+//    SHK_BIND_HOOK(on_item_unlock, on_item_unlock_hook);
 
     MULTI_LOG("Bound hooks\n");
 }

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -164,16 +164,16 @@ void goldBoltUpdateHook(Moby* moby) {
     ((GoldBolt*)moby)->update();
 }
 
-//SHK_HOOK(void, on_item_unlock, int*);
-//void on_item_unlock_hook(int* item_id) {
+SHK_HOOK(void, on_item_unlock, int*);
+void on_item_unlock_hook(int* item_id) {
 //    if (Game::shared().client()) {
 //        Game::shared().client()->send(Packet::make_unlock_item_packet(*item_id));
 //    }
-//    SHK_CALL_HOOK(on_item_unlock, item_id);
-////    if (*item_id == 0xa) { // bomb glove
-////        SHK_CALL_HOOK(on_item_unlock, item_id);
-////    }
-//}
+    SHK_CALL_HOOK(on_item_unlock, item_id);
+//    if (*item_id == 0xa) { // bomb glove
+//        SHK_CALL_HOOK(on_item_unlock, item_id);
+//    }
+}
 
 void rc1_init() {
     MULTI_LOG("Multiplayer initializing.\n");
@@ -192,7 +192,7 @@ void rc1_init() {
     SHK_BIND_HOOK(cellGameBootCheck, cellGameBootCheckHook);
     SHK_BIND_HOOK(cellGameContentPermit, cellGameContentPermitHook);
     SHK_BIND_HOOK(goldBoltUpdate, goldBoltUpdateHook);
-//    SHK_BIND_HOOK(on_item_unlock, on_item_unlock_hook);
+    SHK_BIND_HOOK(on_item_unlock, on_item_unlock_hook);
 
     MULTI_LOG("Bound hooks\n");
 }

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -168,14 +168,11 @@ SHK_HOOK(void, on_item_unlock, int*);
 void on_item_unlock_hook(int* item_id) {
     Client* client = Game::shared().client();
     if (client != nullptr) {
-        Packet* packet = Packet::make_unlock_item_packet(*item_id);
-//        client->make_ack(packet, nullptr);
-//        client->send(packet);
+        Packet* packet = Packet::make_unlock_item_packet(item_id);
+        client->make_ack(packet, nullptr);
+        client->send(packet);
     }
-//    if (Game::shared().client()) {
-//        Game::shared().client()->send(Packet::make_unlock_item_packet(*item_id));
-//    }
-//    SHK_CALL_HOOK(on_item_unlock, item_id);
+    SHK_CALL_HOOK(on_item_unlock, item_id);
 //    if (*item_id == 0xa) { // bomb glove
 //        SHK_CALL_HOOK(on_item_unlock, item_id);
 //    }

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -146,7 +146,9 @@ void on_item_unlock_hook(int* item_id) {
     if (Game::shared().client()) {
             Game::shared().client()->send(Packet::make_unlock_item_packet(*item_id));
         }
-    //SHK_CALL_HOOK(on_item_unlock, item_id); // probably not send this by default and do it later instead
+    if (*item_id == 0xa) { // bomb glove
+        SHK_CALL_HOOK(on_item_unlock, item_id); // probably not send this by default and do it later instead
+    }
 }
 
 void rc1_init() {

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -168,7 +168,7 @@ SHK_HOOK(void, on_item_unlock, int*);
 void on_item_unlock_hook(int* item_id) {
     Client* client = Game::shared().client();
     if (client != nullptr) {
-//        Packet* packet = Packet::make_unlock_item_packet(*item_id);
+        Packet* packet = Packet::make_unlock_item_packet(*item_id);
 //        client->make_ack(packet, nullptr);
 //        client->send(packet);
     }

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -167,11 +167,11 @@ void goldBoltUpdateHook(Moby* moby) {
 SHK_HOOK(void, on_item_unlock, int*);
 void on_item_unlock_hook(int* item_id) {
     Client* client = Game::shared().client();
-    if (client != nullptr) {
-        Packet* packet = Packet::make_unlock_item_packet(*item_id);
-//        client->make_ack(packet, nullptr);
-//        client->send(packet);
-    }
+//    if (client != nullptr) {
+//        Packet* packet = Packet::make_unlock_item_packet(*item_id);
+////        client->make_ack(packet, nullptr);
+////        client->send(packet);
+//    }
 //    if (Game::shared().client()) {
 //        Game::shared().client()->send(Packet::make_unlock_item_packet(*item_id));
 //    }

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -169,7 +169,7 @@ void on_item_unlock_hook(int* item_id) {
 //    if (Game::shared().client()) {
 //        Game::shared().client()->send(Packet::make_unlock_item_packet(*item_id));
 //    }
-    SHK_CALL_HOOK(on_item_unlock, item_id);
+//    SHK_CALL_HOOK(on_item_unlock, item_id);
 //    if (*item_id == 0xa) { // bomb glove
 //        SHK_CALL_HOOK(on_item_unlock, item_id);
 //    }

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -172,7 +172,7 @@ void on_item_unlock_hook(int item_id) {
         client->make_ack(packet, nullptr);
         client->send(packet);
     }
-    SHK_CALL_HOOK(on_item_unlock, item_id);
+//    SHK_CALL_HOOK(on_item_unlock, item_id);
 //    if (*item_id == 0xa) { // bomb glove
 //        SHK_CALL_HOOK(on_item_unlock, item_id);
 //    }

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -181,10 +181,10 @@ void on_item_unlock_hook(int item_id) {
     }
 }
 
-SHK_HOOK(void, on_vendor_thingy, int);
-void on_vendor_thingy_hook(int item) {
+SHK_HOOK(void, on_vendor_thing, int);
+void on_vendor_thing_hook(int item) {
     Logger::debug("Vendor thingy hit with item: %d", item);
-    SHK_CALL_HOOK(on_vendor_thingy, item);
+    SHK_CALL_HOOK(on_vendor_thing, item);
 }
 
 void rc1_init() {
@@ -205,7 +205,7 @@ void rc1_init() {
     SHK_BIND_HOOK(cellGameContentPermit, cellGameContentPermitHook);
     SHK_BIND_HOOK(goldBoltUpdate, goldBoltUpdateHook);
     SHK_BIND_HOOK(on_item_unlock, on_item_unlock_hook);
-    SHK_BIND_HOOK(on_vendor_thingy, on_vendor_thingy_hook);
+    SHK_BIND_HOOK(on_vendor_thing, on_vendor_thing_hook);
 
     MULTI_LOG("Bound hooks\n");
 }

--- a/prx/rc1/rc1.h
+++ b/prx/rc1/rc1.h
@@ -40,7 +40,8 @@ SHK_FUNCTION_DEFINE_STATIC_2(0xb72b0, u64, transition_to_movement_state, u32, st
 SHK_FUNCTION_DEFINE_STATIC_2(0x112e18, void, unlock_item, u32, item, u8, equipped);
 SHK_FUNCTION_DEFINE_STATIC_0(0x164c58, void, load_destination_planet);
 SHK_FUNCTION_DEFINE_STATIC_1(0xccda0, void, toast_message, char*, message);
-SHK_FUNCTION_DEFINE_STATIC_1(0x4f8d38, void, vendor_thing, int, item);
+SHK_FUNCTION_DEFINE_STATIC_1(0x112c20, void, unlock_planet, int, planet);
+//SHK_FUNCTION_DEFINE_STATIC_1(0x4f8d38, void, vendor_thing, int, item);
 
 SHK_FUNCTION_DEFINE_STATIC_2(0x151e70, void, set_spawn_point, Vec4*, position, Vec4*, rotation);
 

--- a/prx/rc1/rc1.h
+++ b/prx/rc1/rc1.h
@@ -40,6 +40,7 @@ SHK_FUNCTION_DEFINE_STATIC_2(0xb72b0, u64, transition_to_movement_state, u32, st
 SHK_FUNCTION_DEFINE_STATIC_2(0x112e18, void, unlock_item, u32, item, u8, equipped);
 SHK_FUNCTION_DEFINE_STATIC_0(0x164c58, void, load_destination_planet);
 SHK_FUNCTION_DEFINE_STATIC_1(0xccda0, void, toast_message, char*, message);
+SHK_FUNCTION_DEFINE_STATIC_1(0x4f8d38, void, vendor_thingy, int, item);
 
 SHK_FUNCTION_DEFINE_STATIC_2(0x151e70, void, set_spawn_point, Vec4*, position, Vec4*, rotation);
 

--- a/prx/rc1/rc1.h
+++ b/prx/rc1/rc1.h
@@ -40,7 +40,7 @@ SHK_FUNCTION_DEFINE_STATIC_2(0xb72b0, u64, transition_to_movement_state, u32, st
 SHK_FUNCTION_DEFINE_STATIC_2(0x112e18, void, unlock_item, u32, item, u8, equipped);
 SHK_FUNCTION_DEFINE_STATIC_0(0x164c58, void, load_destination_planet);
 SHK_FUNCTION_DEFINE_STATIC_1(0xccda0, void, toast_message, char*, message);
-SHK_FUNCTION_DEFINE_STATIC_1(0x4f8d38, void, vendor_thingy, int, item);
+SHK_FUNCTION_DEFINE_STATIC_1(0x4f8d38, void, vendor_thing, int, item);
 
 SHK_FUNCTION_DEFINE_STATIC_2(0x151e70, void, set_spawn_point, Vec4*, position, Vec4*, rotation);
 

--- a/prx/rc1/rc1.h
+++ b/prx/rc1/rc1.h
@@ -1,7 +1,9 @@
 #ifdef GAME_RC1
 
-#ifndef RC1_H
-#define RC1_H
+//#ifndef RC1_H
+//#define RC1_H
+
+#pragma once
 
 #include <lib/shk.h>
 #include <lib/types.h>
@@ -30,10 +32,7 @@ extern int game_ticks;
 
 extern int current_weapon;
 
-#ifndef __itenGivenByServerVariable
-#define __itemGivenByServerVariable
 extern int itemGivenByServer = 0;
-#endif
 
 SHK_FUNCTION_DEFINE_STATIC_2(0x4fe52c, void*, kalloc, void*, ptr, size_t, len);
 SHK_FUNCTION_DEFINE_STATIC_3(0x650764, int, sys_mmapper_allocate_memory, size_t, size, u64, flags, void*, addr);
@@ -161,5 +160,5 @@ void rc1_shutdown();
 }
 #endif
 
-#endif // RC1_H
+//#endif // RC1_H
 #endif // GAME_RC1

--- a/prx/rc1/rc1.h
+++ b/prx/rc1/rc1.h
@@ -32,6 +32,8 @@ extern int current_weapon;
 
 extern int itemGivenByServer;
 
+extern int planetUnlockedByServer;
+
 SHK_FUNCTION_DEFINE_STATIC_2(0x4fe52c, void*, kalloc, void*, ptr, size_t, len);
 SHK_FUNCTION_DEFINE_STATIC_3(0x650764, int, sys_mmapper_allocate_memory, size_t, size, u64, flags, void*, addr);
 SHK_FUNCTION_DEFINE_STATIC_3(0x4e8470, void, new_game, int, p1, void*, p2, u64, p3);

--- a/prx/rc1/rc1.h
+++ b/prx/rc1/rc1.h
@@ -13,8 +13,6 @@
 extern "C" {
 #endif
 
-extern int itemGivenByServer = 0;
-
 typedef enum GameState {
     PlayerControl = 0,
     Movie = 1,
@@ -31,6 +29,8 @@ typedef enum GameState {
 extern int game_ticks;
 
 extern int current_weapon;
+
+extern int itemGivenByServer;
 
 SHK_FUNCTION_DEFINE_STATIC_2(0x4fe52c, void*, kalloc, void*, ptr, size_t, len);
 SHK_FUNCTION_DEFINE_STATIC_3(0x650764, int, sys_mmapper_allocate_memory, size_t, size, u64, flags, void*, addr);

--- a/prx/rc1/rc1.h
+++ b/prx/rc1/rc1.h
@@ -1,9 +1,7 @@
 #ifdef GAME_RC1
 
-//#ifndef RC1_H
-//#define RC1_H
-
-#pragma once
+#ifndef RC1_H
+#define RC1_H
 
 #include <lib/shk.h>
 #include <lib/types.h>
@@ -32,7 +30,7 @@ extern int game_ticks;
 
 extern int current_weapon;
 
-extern int itemGivenByServer = 0;
+extern int itemGivenByServer;
 
 SHK_FUNCTION_DEFINE_STATIC_2(0x4fe52c, void*, kalloc, void*, ptr, size_t, len);
 SHK_FUNCTION_DEFINE_STATIC_3(0x650764, int, sys_mmapper_allocate_memory, size_t, size, u64, flags, void*, addr);
@@ -160,5 +158,5 @@ void rc1_shutdown();
 }
 #endif
 
-//#endif // RC1_H
+#endif // RC1_H
 #endif // GAME_RC1

--- a/prx/rc1/rc1.h
+++ b/prx/rc1/rc1.h
@@ -13,6 +13,8 @@
 extern "C" {
 #endif
 
+extern int itemGivenByServer = 0;
+
 typedef enum GameState {
     PlayerControl = 0,
     Movie = 1,

--- a/prx/rc1/rc1.h
+++ b/prx/rc1/rc1.h
@@ -30,7 +30,10 @@ extern int game_ticks;
 
 extern int current_weapon;
 
-extern int itemGivenByServer;
+#ifndef __itenGivenByServerVariable
+#define __itemGivenByServerVariable
+extern int itemGivenByServer = 0;
+#endif
 
 SHK_FUNCTION_DEFINE_STATIC_2(0x4fe52c, void*, kalloc, void*, ptr, size_t, len);
 SHK_FUNCTION_DEFINE_STATIC_3(0x650764, int, sys_mmapper_allocate_memory, size_t, size, u64, flags, void*, addr);


### PR DESCRIPTION
Multiplayer client extended to require the game server to "give/unlock" items and planets.
Rather than the original functions, a request is sent to the server. Upon server command a flag is set to allow the original behavior of the unlock_planet and unlock_item functions to execute.
This is per definition a breaking change without the matching Lawrence extension