### PR TITLE
Teamruns

### DIFF
--- a/prx/rc1/Game.cpp
+++ b/prx/rc1/Game.cpp
@@ -97,12 +97,6 @@ void Game::on_tick() {
         ratchet_moby->color = custom_player_color;
     }
 
-    if (previous_bolt_count != player_bolts) {
-        s32 bolt_diff = player_bolts - previous_bolt_count;
-        if (client_) client_->send(Packet::make_bolt_count_changed_packet(bolt_diff, player_bolts));
-        previous_bolt_count = player_bolts;
-    }
-
     if (client_) {
         client_->flush();
     }

--- a/prx/rc1/Game.cpp
+++ b/prx/rc1/Game.cpp
@@ -97,6 +97,12 @@ void Game::on_tick() {
         ratchet_moby->color = custom_player_color;
     }
 
+    if (previous_bolt_count != player_bolts) {
+        s32 bolt_diff = player_bolts - previous_bolt_count;
+        if (client_) client_->send(Packet::make_bolt_count_changed_packet(bolt_diff));
+        previous_bolt_count = player_bolts;
+    }
+
     if (client_) {
         client_->flush();
     }

--- a/prx/rc1/Game.cpp
+++ b/prx/rc1/Game.cpp
@@ -99,7 +99,7 @@ void Game::on_tick() {
 
     if (previous_bolt_count != player_bolts) {
         s32 bolt_diff = player_bolts - previous_bolt_count;
-        if (client_) client_->send(Packet::make_bolt_count_changed_packet(bolt_diff));
+        if (client_) client_->send(Packet::make_bolt_count_changed_packet(bolt_diff, player_bolts));
         previous_bolt_count = player_bolts;
     }
 

--- a/prx/rc1/Game.h
+++ b/prx/rc1/Game.h
@@ -45,15 +45,11 @@ public:
     void refresh_level_flags();
 
     void alert(String& message);
-
-    s32 previous_bolt_count; // man idk if this being public is even legal but it seems needed
 private:
     Game() {
         previous_user_option_camera_left_right_movement = -1;
         previous_user_option_camera_up_down_movement = -1;
         previous_user_option_camera_rotation_speed = -1;
-
-        previous_bolt_count = player_bolts;
     }
     Game(Game const&);
 

--- a/prx/rc1/Game.h
+++ b/prx/rc1/Game.h
@@ -15,6 +15,9 @@
 
 typedef void (*ServerQueryCallback)(Vector<GameServer*>* servers);
 
+static char* level_flags1 = (char*)0xa0ca84;
+static char* level_flags2 = (char*)0xa0cd1c;
+
 struct Game {
 public:
     static Game& shared() {
@@ -39,6 +42,8 @@ public:
     void connect_to(char* ip, int port);
     void query_servers(int directory_id, ServerQueryCallback callback);
 
+    void refresh_level_flags();
+
     void alert(String& message);
 private:
     Game() {
@@ -52,12 +57,20 @@ private:
 
     Client* client_;
 
+    int last_planet_;
+
     int previous_user_option_camera_left_right_movement;
     int previous_user_option_camera_up_down_movement;
     int previous_user_option_camera_rotation_speed;
     bool restored_camera_options_;
 
+    bool reload_level_flags_;
+    u8 level_flags1_[0x10];
+    u8 level_flags2_[0x100];
+
     static ServerQueryCallback server_query_callback_;
+
+    void check_level_flags();
 };
 
 

--- a/prx/rc1/Game.h
+++ b/prx/rc1/Game.h
@@ -45,11 +45,15 @@ public:
     void refresh_level_flags();
 
     void alert(String& message);
+
+    s32 previous_bolt_count; // man idk if this being public is even legal but it seems needed
 private:
     Game() {
         previous_user_option_camera_left_right_movement = -1;
         previous_user_option_camera_up_down_movement = -1;
         previous_user_option_camera_rotation_speed = -1;
+
+        previous_bolt_count = player_bolts;
     }
     Game(Game const&);
 

--- a/prx/rc1/Moby.h
+++ b/prx/rc1/Moby.h
@@ -3,11 +3,20 @@
 
 #include <lib/shk.h>
 #include <lib/types.h>
+#include "Moby.h"
 
 //#include <lib/common.h>
 //#include <rc1/common.h>
 
 #ifdef __cplusplus
+
+// Should be in Packet.h, but something is stopping us from including it here so we'll just define it here
+typedef struct {
+    u16 offset;
+    u16 size;
+    u32 value;
+} MPPacketChangeMobyValuePayload;
+
 extern "C" {
 #endif
 
@@ -223,7 +232,11 @@ struct Moby {
     void set_animation(char animation_id, char animation_frame, u32 duration);
     void check_collision();
 
+    void change_values(MPPacketChangeMobyValuePayload* changes, size_t num, u16 value_type);
+
     static Moby* spawn(unsigned short o_class, unsigned short flags, uint16_t modeBits);
+    static Moby* find_by_uid(u16 uid);
+    static Moby* find_first_oclass(u16 o_class);
 #endif
 }
 #ifdef __cplusplus

--- a/prx/rc1/PersistentStorage.cpp
+++ b/prx/rc1/PersistentStorage.cpp
@@ -29,13 +29,9 @@ void PersistentStorage::persist() {
 void PersistentStorage::load() {
     int err = cellFsOpen(String::format("/dev_hdd0/game/NPEA00385/USRDIR/%s", filename.c_str()).c_str(), CELL_FS_O_RDONLY|CELL_FS_O_CREAT, &file_descriptor_, nullptr, 0);
 
-    Logger::debug("oh wow we're loading wowow");
-
     char buffer[4096];
     uint64_t num_read;
     cellFsRead(file_descriptor_, (void*)buffer, sizeof(buffer), &num_read);
-
-    Logger::debug("Read that shit");
 
     Vector<String> parts = String(buffer).split("\n");
     for (int i = 0; i < parts.size(); i++) {
@@ -43,8 +39,6 @@ void PersistentStorage::load() {
         if (key_value.size() < 2) {
             continue;
         }
-
-        Logger::debug("Oh we in here");
 
         String key = key_value[0];
         String value = key_value[1];
@@ -59,8 +53,6 @@ void PersistentStorage::load() {
             set(key, __atoi(value.c_str()));
         }
     }
-
-    Logger::debug("we out");
 
     cellFsClose(file_descriptor_);
 }

--- a/prx/rc1/Player.cpp
+++ b/prx/rc1/Player.cpp
@@ -19,7 +19,7 @@ void Player::on_tick() {
     MPPacketMobyUpdate* payload = (MPPacketMobyUpdate*)packet->body;
     payload->uuid = 0;  // Player moby is always uuid 0
     payload->flags |= ratchet_moby != 0 ? 1 : 0;
-    payload->o_class = 0;
+    payload->o_class = ratchet_moby->oClass;
     payload->level = (u16)current_planet;
     payload->animation_id = ratchet_moby != 0 ? ratchet_moby->animationID : 0;
     payload->animation_duration = 10;

--- a/prx/rc1/Player.cpp
+++ b/prx/rc1/Player.cpp
@@ -53,6 +53,12 @@ void Player::on_tick() {
             Packet* game_state_packet = Packet::make_game_state_changed_packet(game_state);
             client->send(game_state_packet);
         }
+
+        if (previous_bolt_count != player_bolts) {
+            s32 bolt_diff = player_bolts - previous_bolt_count;
+            client->send(Packet::make_bolt_count_changed_packet(bolt_diff, player_bolts));
+            previous_bolt_count = player_bolts;
+        }
     }
 
     last_game_state = game_state;

--- a/prx/rc1/Player.cpp
+++ b/prx/rc1/Player.cpp
@@ -54,7 +54,8 @@ void Player::on_tick() {
             client->send(game_state_packet);
         }
 
-        if (previous_bolt_count != player_bolts) {
+        if ((enable_communication_bitmap & ENABLE_ON_GET_BOLTS) &&
+                previous_bolt_count != player_bolts) {
             s32 bolt_diff = player_bolts - previous_bolt_count;
             client->send(Packet::make_bolt_count_changed_packet(bolt_diff, player_bolts));
             previous_bolt_count = player_bolts;

--- a/prx/rc1/Player.h
+++ b/prx/rc1/Player.h
@@ -25,8 +25,11 @@ struct Player {
 
     void on_tick();
     void on_respawned();
+    s32 previous_bolt_count;
 private:
-    Player() {}
+    Player() {
+        previous_bolt_count = player_bolts;
+    }
     Player(Player const&);
 };
 

--- a/prx/rc1/globals.ld
+++ b/prx/rc1/globals.ld
@@ -36,6 +36,10 @@ coll_output = 0xa10940;
 n_coll_mobys = 0xa10950;
 coll_moby_out = 0xa10958;
 
+mclass_table = 0xa34c00;
+
+player_type = 0x96bd84;
+
 user_option_camera_left_right_movement = 0x71fb38;
 user_option_camera_up_down_movement = 0x71fb3c;
 user_option_camera_rotation_speed = 0x71fb40;

--- a/prx/rc1/hooks.yml
+++ b/prx/rc1/hooks.yml
@@ -51,3 +51,7 @@ _unlock_item:
 _unlock_level:
     addr: 0x112c20
     replacedInstr: stdu r1, -0xe0(r1)
+
+_unlock_skillpoint:
+    addr: 0x11b728
+    replacedInstr: stdu r1, -0xa0(r1)

--- a/prx/rc1/multiplayer/Client.cpp
+++ b/prx/rc1/multiplayer/Client.cpp
@@ -66,6 +66,15 @@ void Client::reset() {
     connected_ = false;
     sockfd_ = 0;
 
+    ack_id_ = 0;
+    ack_cycle_ = 0;
+
+    memset(&acked_, 0, sizeof(acked_));
+    memset(&unacked_, 0, sizeof(unacked_));
+
+    received_ = 0;
+    send_buffer_len = 0;
+
     _connect();
 }
 

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -321,7 +321,7 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             } else {
                 player_bolts += (s32)packet->value;
             }
-            Game::shared().previous_bolt_count = player_bolts;
+            Player::shared().previous_bolt_count = player_bolts;
             break;
         }
         case MP_STATE_TYPE_UNLOCK_LEVEL: {

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -364,6 +364,10 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             Game::shared().refresh_level_flags();
             break;
         }
+        case MP_STATE_TYPE_COMMUNICATION_FLAGS: {
+            enable_communication_bitmap = (EnableCommunicationsFlags)packet->value;
+            break;
+        }
         default: {
             Logger::error("Server asked us to set unknown state type %d", packet->state_type);
         }

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -323,6 +323,10 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             unlock_level(level);
             break;
         }
+        case MP_STATE_TYPE_UNLOCK_SKILLPOINT: {
+            unlock_skillpoint((u8)packet->value);
+            break;
+        }
         case MP_STATE_TYPE_LEVEL_FLAG: {
             int level = (int)(packet->offset >> 24) & 0xFF;
             int type = (int)(packet->offset >> 16) & 0xFF;

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -315,7 +315,8 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             break;
         }
         case MP_STATE_TYPE_GIVE_BOLTS: {
-            player_bolts += packet->value;
+            player_bolts += (s32)packet->value;
+            Game::shared().previous_bolt_count = player_bolts;
             break;
         }
         case MP_STATE_TYPE_UNLOCK_LEVEL: {

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -315,7 +315,12 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             break;
         }
         case MP_STATE_TYPE_GIVE_BOLTS: {
-            player_bolts += (s32)packet->value;
+            #define SET_BOLTS 1
+            if (packet->offset == SET_BOLTS) {
+                player_bolts = (s32)packet->value;
+            } else {
+                player_bolts += (s32)packet->value;
+            }
             Game::shared().previous_bolt_count = player_bolts;
             break;
         }

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -40,6 +40,11 @@ void GameClient::reset() {
     clear_hybrid_mobys();
     moby_delete_all();
 
+    for (size_t i = 0; i < monitored_addresses_.size(); i++) {
+        delete monitored_addresses_[i];
+    }
+    monitored_addresses_.resize(0);
+
     Client::reset();
 }
 
@@ -311,7 +316,16 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             break;
         }
         case MP_STATE_TYPE_ARBITRARY: {
-            *(int*)(packet->offset) = (int)packet->value;
+            memcpy((unsigned char*)packet->offset, &packet->value, packet->flags);
+
+            // If we're monitoring this address, we must change its old_value
+            for (size_t i = 0; i < monitored_addresses_.size(); i++) {
+                if (monitored_addresses_[i]->offset == packet->offset) {
+                    memcpy(&monitored_addresses_[i]->old_value, &packet->value, packet->flags);
+                    break;
+                }
+            }
+
             break;
         }
         case MP_STATE_TYPE_GIVE_BOLTS: {
@@ -462,6 +476,28 @@ void GameClient::clear_hybrid_mobys() {
     hybrid_mobys_.resize(0);
 }
 
+void GameClient::monitor_address(MPPacketMonitorAddress* packet) {
+    if (packet->size > 4) {
+        Logger::error("Server tried to monitor address with size %d. Ignoring.", packet->size);
+        return;
+    }
+
+    Logger::debug("Monitoring address %p with size %d", packet->address, packet->size);
+
+    MonitoredValue* value = new MonitoredValue();
+    value->offset = packet->address;
+    value->size = packet->size;
+
+    memcpy(&value->old_value, (unsigned char*)packet->address, packet->size);
+
+    // Send initial value back to server
+    Packet* addrChangedPacket = Packet::make_address_changed_packet(packet->address, packet->size, value->old_value, value->old_value);
+    make_ack(addrChangedPacket, nullptr);
+    send(addrChangedPacket);
+
+    monitored_addresses_.push_back(value);
+}
+
 bool GameClient::update(MPPacketHeader *header, void *packet_data) {
     if (!Client::update(header, packet_data)) {
         return false;
@@ -520,6 +556,10 @@ bool GameClient::update(MPPacketHeader *header, void *packet_data) {
         }
         case MP_PACKET_REGISTER_HYBRID_MOBY: {
             register_hybrid_moby((MPPacketRegisterHybridMoby*)packet_data);
+            break;
+        }
+        case MP_PACKET_MONITOR_ADDRESS: {
+            monitor_address((MPPacketMonitorAddress*)packet_data);
             break;
         }
         default:
@@ -589,6 +629,21 @@ void GameClient::on_tick() {
 
     for (size_t i = 0; i < hybrid_mobys_.size(); i++) {
         hybrid_mobys_[i]->on_tick();
+    }
+
+    for (size_t i = 0; i < monitored_addresses_.size(); i++) {
+        MonitoredValue* address_value = monitored_addresses_[i];
+
+        u32 value;
+        memcpy(&value, (char*)address_value->offset, address_value->size);
+
+        if (value != address_value->old_value) {
+            Packet* packet = Packet::make_address_changed_packet(address_value->offset, address_value->size, address_value->old_value, value);
+            make_ack(packet, nullptr);
+            send(packet);
+        }
+
+        address_value->old_value = value;
     }
 
     ticks_ += 1;

--- a/prx/rc1/multiplayer/GameClient.cpp
+++ b/prx/rc1/multiplayer/GameClient.cpp
@@ -294,6 +294,23 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             int level = (int)(packet->value);
             unlock_level(level);
         }
+        case MP_STATE_TYPE_LEVEL_FLAG: {
+            int level = (int)(packet->offset >> 24) & 0xFF;
+            int type = (int)(packet->offset >> 16) & 0xFF;
+            int offset = (int)(packet->offset) & 0xFFFF;
+
+            Logger::trace("Setting level flag %d %d %d", level, type, offset);
+
+            if (type == MP_LEVEL_FLAG_TYPE_1) {
+                level_flags1[level * 0x10 + offset] = packet->value;
+            }
+            if (type == MP_LEVEL_FLAG_TYPE_2) {
+                level_flags2[level * 0x100 + offset] = packet->value;
+            }
+
+            Game::shared().refresh_level_flags();
+            break;
+        }
         default: {
             Logger::error("Server asked us to set unknown state type %d", packet->state_type);
         }

--- a/prx/rc1/multiplayer/GameClient.h
+++ b/prx/rc1/multiplayer/GameClient.h
@@ -14,6 +14,7 @@
 
 #include "../views/RemoteView.h"
 #include "HybridMoby.h"
+#include "MonitoredValue.h"
 
 // Maximum amount of moby's we can deal with
 #define MAX_MP_MOBYS 1024
@@ -33,6 +34,7 @@ struct GameClient : public Client {
     void register_hybrid_moby(MPPacketRegisterHybridMoby* packet);
     void refresh_hybrid_mobys();
     void clear_hybrid_mobys();
+    void monitor_address(MPPacketMonitorAddress* packet);
     bool update(MPPacketHeader* header, void* packet_data);
     void on_tick();
 
@@ -41,6 +43,7 @@ private:
     char* ip_;
     Vector<Moby*> mobys_;
     Vector<HybridMoby*> hybrid_mobys_;
+    Vector<MonitoredValue*> monitored_addresses_;
     long ticks_;
 
     bool connection_complete_;

--- a/prx/rc1/multiplayer/GameClient.h
+++ b/prx/rc1/multiplayer/GameClient.h
@@ -13,6 +13,7 @@
 #include <lib/vector.h>
 
 #include "../views/RemoteView.h"
+#include "HybridMoby.h"
 
 // Maximum amount of moby's we can deal with
 #define MAX_MP_MOBYS 1024
@@ -22,12 +23,16 @@ struct GameClient : public Client {
 
     void update_moby(MPPacketMobyUpdate* packet);
     void update_moby_ex(MPPacketMobyExtended* packet);
+    void change_moby_value(MPPacketChangeMobyValue* packet);
     void moby_delete(MPPacketMobyDelete* packet);
     void moby_clear_all();
     void moby_delete_all();
     void update_set_state(MPPacketSetState* packet);
     void update_set_text(MPPacketSetHUDText* packet);
     void toast_message(MPPacketToastMessage* packet);
+    void register_hybrid_moby(MPPacketRegisterHybridMoby* packet);
+    void refresh_hybrid_mobys();
+    void clear_hybrid_mobys();
     bool update(MPPacketHeader* header, void* packet_data);
     void on_tick();
 
@@ -35,6 +40,7 @@ struct GameClient : public Client {
 private:
     char* ip_;
     Vector<Moby*> mobys_;
+    Vector<HybridMoby*> hybrid_mobys_;
     long ticks_;
 
     bool connection_complete_;

--- a/prx/rc1/multiplayer/HybridMoby.cpp
+++ b/prx/rc1/multiplayer/HybridMoby.cpp
@@ -1,0 +1,240 @@
+#include "HybridMoby.h"
+
+#include <rc1/Game.h>
+
+HybridMoby::HybridMoby(Moby* moby, u16 _uid) {
+    Logger::trace("Creating HybridMoby for %d", _uid);
+
+    moby_ = moby;
+    uid = _uid;
+}
+
+HybridMoby::~HybridMoby() {
+    Logger::trace("Destroying HybridMoby for %d", uid);
+
+    for (size_t i = 0; i < monitored_attributes_.size(); i++) {
+        delete monitored_attributes_[i];
+    }
+
+    for (size_t i = 0; i < monitored_pvars_.size(); i++) {
+        delete monitored_pvars_[i];
+    }
+
+    monitored_attributes_.resize(0);
+    monitored_pvars_.resize(0);
+}
+
+void HybridMoby::monitor_attribute(u32 offset, u32 size) {
+    Logger::debug("Monitoring attribute %d with size %d", offset, size);
+    for (size_t i = 0; i < monitored_attributes_.size(); i++) {
+        MonitoredValue* value = monitored_attributes_[i];
+        if (value->offset == offset) {
+            return;
+        }
+    }
+
+    MonitoredValue* value = new MonitoredValue();
+    value->offset = offset;
+    value->size = size;
+    value->old_value = 0;
+
+    if (size == 1) {
+        memcpy(&value->old_value, (unsigned char*)moby_ + offset, 1);
+    } else if (size == 2) {
+        memcpy(&value->old_value, (unsigned char*)moby_ + offset, 2);
+    } else {
+        memcpy(&value->old_value, (unsigned char*)moby_ + offset, 4);
+    }
+
+    // Send initial value to the client, should be easily ignorable as both old and new values are the same
+    if (Game::shared().client()) {
+        Client* client = Game::shared().client();
+
+        Packet* packet = Packet::make_monitored_value_changed_packet(
+                uid,
+                value->offset,
+                value->size,
+                MP_MONITORED_VALUE_TYPE_ATTR,
+                value->old_value,
+                value->old_value
+        );
+
+        // NOTE: We could bundle all the changes into one packet
+        client->make_ack(packet, nullptr);
+        client->send(packet);
+    }
+
+    monitored_attributes_.push_back(value);
+}
+
+void HybridMoby::monitor_pvar(u32 offset, u32 size) {
+    Logger::debug("Monitoring pvar %d with size %d", offset, size);
+    for (size_t i = 0; i < monitored_pvars_.size(); i++) {
+        MonitoredValue* value = monitored_pvars_[i];
+        if (value->offset == offset) {
+            return;
+        }
+    }
+
+    MonitoredValue* value = new MonitoredValue();
+    value->offset = offset;
+    value->size = size;
+
+    if (size == 1) {
+        memcpy(&value->old_value, (unsigned char*)moby_->pVars + offset, 1);
+    } else if (size == 2) {
+        memcpy(&value->old_value, (unsigned char*)moby_->pVars + offset, 2);
+    } else {
+        memcpy(&value->old_value, (unsigned char*)moby_->pVars + offset, 4);
+    }
+
+    // Send initial value to the client, should be easily ignorable as both old and new values are the same
+    if (Game::shared().client()) {
+        Client* client = Game::shared().client();
+
+        Packet* packet = Packet::make_monitored_value_changed_packet(
+                uid,
+                value->offset,
+                value->size,
+                MP_MONITORED_VALUE_TYPE_PVAR,
+                value->old_value,
+                value->old_value
+        );
+
+        // NOTE: We could bundle all the changes into one packet
+        client->make_ack(packet, nullptr);
+        client->send(packet);
+    }
+
+
+    monitored_pvars_.push_back(value);
+}
+
+void HybridMoby::on_tick() {
+    if (game_state != PlayerControl) {
+        return;
+    }
+
+    for (size_t i = 0; i < monitored_attributes_.size(); i++) {
+        MonitoredValue* value = monitored_attributes_[i];
+        u32 new_value;
+
+        if (value->size == 1) {
+            u8 temp_value;
+            memcpy(&temp_value, (unsigned char*)moby_ + value->offset, 1);
+            new_value = temp_value;
+        } else if (value->size == 2) {
+            u16 temp_value;
+            memcpy(&temp_value, (unsigned char*)moby_ + value->offset, 2);
+            new_value = temp_value;
+        } else {
+            memcpy(&new_value, (unsigned char*)moby_ + value->offset, 4);
+        }
+
+        if (new_value != value->old_value) {
+            Logger::trace("Attribute %d changed from %d to %d", value->offset, value->old_value, new_value);
+            if (Game::shared().client()) {
+                Client* client = Game::shared().client();
+
+                Packet* packet = Packet::make_monitored_value_changed_packet(
+                        uid,
+                        value->offset,
+                        value->size,
+                        MP_MONITORED_VALUE_TYPE_ATTR,
+                        value->old_value,
+                        new_value
+                );
+
+                // NOTE: We could bundle all the changes into one packet
+                client->make_ack(packet, nullptr);
+                client->send(packet);
+            }
+
+            value->old_value = new_value;
+        }
+    }
+
+    for (size_t i = 0; i < monitored_pvars_.size(); i++) {
+        MonitoredValue* value = monitored_pvars_[i];
+        u32 new_value;
+
+        if (value->size == 1) {
+            u8 temp_value;
+            memcpy(&temp_value, (unsigned char*)moby_->pVars + value->offset, 1);
+            new_value = temp_value;
+        } else if (value->size == 2) {
+            u16 temp_value;
+            memcpy(&temp_value, (unsigned char*)moby_->pVars + value->offset, 2);
+            new_value = temp_value;
+        } else {
+            memcpy(&new_value, (unsigned char*)moby_->pVars + value->offset, 4);
+        }
+
+        if (new_value != value->old_value) {
+            Logger::debug("Pvar %d changed from %d to %d", value->offset, value->old_value, new_value);
+            if (Game::shared().client()) {
+                Client* client = Game::shared().client();
+
+                Packet* packet = Packet::make_monitored_value_changed_packet(
+                        uid,
+                        value->offset,
+                        value->size,
+                        MP_MONITORED_VALUE_TYPE_PVAR,
+                        value->old_value,
+                        new_value
+                );
+
+                // NOTE: We could bundle all the changes into one packet
+                client->make_ack(packet, nullptr);
+                client->send(packet);
+            }
+
+            value->old_value = new_value;
+        }
+    }
+}
+
+void HybridMoby::refresh_old_values_without_notifying_server() {
+    Logger::trace("Refreshing attributes for %d without notifying server for size %d", uid, monitored_attributes_.size());
+    for (size_t i = 0; i < monitored_attributes_.size(); i++) {
+        MonitoredValue* value = monitored_attributes_[i];
+        u32 new_value;
+
+        if (value->size == 1) {
+            u8 temp_value;
+            memcpy(&temp_value, (unsigned char*)moby_ + value->offset, 1);
+            new_value = temp_value;
+        } else if (value->size == 2) {
+            u16 temp_value;
+            memcpy(&temp_value, (unsigned char*)moby_ + value->offset, 2);
+            new_value = temp_value;
+        } else {
+            memcpy(&new_value, (unsigned char*)moby_ + value->offset, 4);
+        }
+
+        value->old_value = new_value;
+    }
+
+    Logger::trace("Refreshing pvars for %d without notifying server for size: %d", uid, monitored_pvars_.size());
+    for (size_t i = 0; i < monitored_pvars_.size(); i++) {
+
+        MonitoredValue* value = monitored_pvars_[i];
+        u32 new_value;
+
+        if (value->size == 1) {
+            u8 temp_value;
+            memcpy(&temp_value, (unsigned char*)moby_->pVars + value->offset, 1);
+            new_value = temp_value;
+        } else if (value->size == 2) {
+            u16 temp_value;
+            memcpy(&temp_value, (unsigned char*)moby_->pVars + value->offset, 2);
+            new_value = temp_value;
+        } else {
+            memcpy(&new_value, (unsigned char*)moby_->pVars + value->offset, 4);
+        }
+
+        value->old_value = new_value;
+    }
+
+    Logger::trace("Done refreshing values for %d without notifying server", uid);
+}

--- a/prx/rc1/multiplayer/HybridMoby.h
+++ b/prx/rc1/multiplayer/HybridMoby.h
@@ -1,0 +1,37 @@
+//
+// Created by bordplate on 10/22/2024.
+//
+
+#ifndef RAC1_MULTIPLAYER_HYBRIDMOBY_H
+#define RAC1_MULTIPLAYER_HYBRIDMOBY_H
+
+#include <rc1/Moby.h>
+
+struct MonitoredValue {
+    u32 offset;
+    u32 size;
+    u32 old_value;
+};
+
+struct HybridMoby {
+public:
+    HybridMoby(Moby* moby, u16 uid);
+    ~HybridMoby();
+
+    u16 uid;
+
+    void monitor_attribute(u32 offset, u32 size);
+    void monitor_pvar(u32 offset, u32 size);
+
+    void set_moby(Moby* moby) { moby_ = moby; }
+
+    void on_tick();
+    void refresh_old_values_without_notifying_server();
+private:
+    Moby* moby_;
+
+    Vector<MonitoredValue*> monitored_attributes_;
+    Vector<MonitoredValue*> monitored_pvars_;
+};
+
+#endif //RAC1_MULTIPLAYER_HYBRIDMOBY_H

--- a/prx/rc1/multiplayer/HybridMoby.h
+++ b/prx/rc1/multiplayer/HybridMoby.h
@@ -6,12 +6,7 @@
 #define RAC1_MULTIPLAYER_HYBRIDMOBY_H
 
 #include <rc1/Moby.h>
-
-struct MonitoredValue {
-    u32 offset;
-    u32 size;
-    u32 old_value;
-};
+#include "MonitoredValue.h"
 
 struct HybridMoby {
 public:

--- a/prx/rc1/multiplayer/MonitoredValue.h
+++ b/prx/rc1/multiplayer/MonitoredValue.h
@@ -1,0 +1,16 @@
+//
+// Created by bordplate on 10/27/2024.
+//
+
+#ifndef RAC1_MULTIPLAYER_MONITOREDVALUE_H
+#define RAC1_MULTIPLAYER_MONITOREDVALUE_H
+
+#include <lib/types.h>
+
+struct MonitoredValue {
+    u32 offset;
+    u32 size;
+    u32 old_value;
+};
+
+#endif //RAC1_MULTIPLAYER_MONITOREDVALUE_H

--- a/prx/rc1/multiplayer/Packet.cpp
+++ b/prx/rc1/multiplayer/Packet.cpp
@@ -260,7 +260,7 @@ Packet* Packet::make_level_flag_changed_packet(u16 type, u8 level, u8 size, u16 
     return packet;
 }
 
-Packet* Packet::make_bolt_count_changed_packet(s32 bolt_diff) {
+Packet* Packet::make_bolt_count_changed_packet(s32 bolt_diff, u32 current_bolts) {
     Packet* packet = new Packet(sizeof(MPPacketSetState));
     packet->header->type = MP_PACKET_SET_STATE;
     packet->header->size = sizeof(MPPacketSetState);
@@ -268,6 +268,7 @@ Packet* Packet::make_bolt_count_changed_packet(s32 bolt_diff) {
     MPPacketSetState* body = (MPPacketSetState*)packet->body;
     body->state_type = MP_STATE_TYPE_GIVE_BOLTS;
     body->value = bolt_diff;
+    body->offset = current_bolts;
 
     return packet;
 }

--- a/prx/rc1/multiplayer/Packet.cpp
+++ b/prx/rc1/multiplayer/Packet.cpp
@@ -259,3 +259,15 @@ Packet* Packet::make_level_flag_changed_packet(u16 type, u8 level, u8 size, u16 
 
     return packet;
 }
+
+Packet* Packet::make_bolt_count_changed_packet(s32 bolt_diff) {
+    Packet* packet = new Packet(sizeof(MPPacketSetState));
+    packet->header->type = MP_PACKET_SET_STATE;
+    packet->header->size = sizeof(MPPacketSetState);
+
+    MPPacketSetState* body = (MPPacketSetState*)packet->body;
+    body->state_type = MP_STATE_TYPE_GIVE_BOLTS;
+    body->value = bolt_diff;
+
+    return packet;
+}

--- a/prx/rc1/multiplayer/Packet.cpp
+++ b/prx/rc1/multiplayer/Packet.cpp
@@ -215,6 +215,19 @@ Packet* Packet::make_unlock_level_packet(int level) {
     return packet;
 }
 
+Packet* Packet::make_unlock_skillpoint_packet(u8 skillpoint) {
+    Packet* packet = new Packet(sizeof(MPPacketSetState));
+    packet->header->type = MP_PACKET_SET_STATE;
+    packet->header->size = sizeof(MPPacketSetState);
+
+    MPPacketSetState* body = (MPPacketSetState*)packet->body;
+    body->state_type = MP_STATE_TYPE_UNLOCK_SKILLPOINT;
+    body->value = skillpoint;
+    body->offset = 0;
+
+    return packet;
+}
+
 Packet* Packet::make_monitored_value_changed_packet(u16 uid, u32 offset, u32 size, u8 flags, u32 old_value, u32 new_value) {
     Packet* packet = new Packet(sizeof(MPPacketMonitoredValueChanged));
     packet->header->type = MP_PACKET_MONITORED_VALUE_CHANGED;

--- a/prx/rc1/multiplayer/Packet.cpp
+++ b/prx/rc1/multiplayer/Packet.cpp
@@ -260,6 +260,20 @@ Packet* Packet::make_level_flag_changed_packet(u16 type, u8 level, u8 size, u16 
     return packet;
 }
 
+Packet* Packet::make_address_changed_packet(u32 address, u16 size, u32 old_value, u32 new_value) {
+    Packet* packet = new Packet(sizeof(MPPacketAddressChanged));
+    packet->header->type = MP_PACKET_ADDRESS_CHANGED;
+    packet->header->size = sizeof(MPPacketAddressChanged);
+
+    MPPacketAddressChanged* body = (MPPacketAddressChanged*)packet->body;
+    body->address = address;
+    body->size = size;
+    body->old_value = old_value;
+    body->new_value = new_value;
+
+    return packet;
+}
+
 Packet* Packet::make_bolt_count_changed_packet(s32 bolt_diff, u32 current_bolts) {
     Packet* packet = new Packet(sizeof(MPPacketSetState));
     packet->header->type = MP_PACKET_SET_STATE;

--- a/prx/rc1/multiplayer/Packet.cpp
+++ b/prx/rc1/multiplayer/Packet.cpp
@@ -214,3 +214,18 @@ Packet* Packet::make_unlock_level_packet(int level) {
 
     return packet;
 }
+
+Packet* Packet::make_level_flag_changed_packet(u16 type, u8 level, u8 size, u16 index, u32 value) {
+    Packet* packet = new Packet(sizeof(MPPacketLevelFlagChanged));
+    packet->header->type = MP_PACKET_LEVEL_FLAG_CHANGED;
+    packet->header->size = sizeof(MPPacketLevelFlagChanged);
+
+    MPPacketLevelFlagChanged* body = (MPPacketLevelFlagChanged*)packet->body;
+    body->type = type;
+    body->level = level;
+    body->size = size;
+    body->index = index;
+    body->value = value;
+
+    return packet;
+}

--- a/prx/rc1/multiplayer/Packet.cpp
+++ b/prx/rc1/multiplayer/Packet.cpp
@@ -215,6 +215,23 @@ Packet* Packet::make_unlock_level_packet(int level) {
     return packet;
 }
 
+Packet* Packet::make_monitored_value_changed_packet(u16 uid, u32 offset, u32 size, u8 flags, u32 old_value, u32 new_value) {
+    Packet* packet = new Packet(sizeof(MPPacketMonitoredValueChanged));
+    packet->header->type = MP_PACKET_MONITORED_VALUE_CHANGED;
+    packet->header->size = sizeof(MPPacketMonitoredValueChanged);
+
+    MPPacketMonitoredValueChanged* body = (MPPacketMonitoredValueChanged*)packet->body;
+    body->uid = uid;
+    body->offset = offset;
+    body->size = size;
+    body->flags = flags;
+    body->old_value = old_value;
+    body->new_value = new_value;
+
+    return packet;
+}
+
+
 Packet* Packet::make_level_flag_changed_packet(u16 type, u8 level, u8 size, u16 index, u32 value) {
     Packet* packet = new Packet(sizeof(MPPacketLevelFlagChanged));
     packet->header->type = MP_PACKET_LEVEL_FLAG_CHANGED;

--- a/prx/rc1/multiplayer/Packet.h
+++ b/prx/rc1/multiplayer/Packet.h
@@ -74,6 +74,7 @@ Here is an example of how a packet with type set to MP_PACKET_MOBY_UPDATE and no
 #define MP_PACKET_AUTH               19
 #define MP_PACKET_CREATE_USER        20
 #define MP_PACKET_ERROR_MESSAGE      21
+#define MP_PACKET_LEVEL_FLAG_CHANGED 25
 
 #define MP_PACKET_FLAG_RPC           0x1
 
@@ -196,6 +197,7 @@ typedef struct {
 #define MP_STATE_TYPE_UNLOCK_ITEM 12
 #define MP_STATE_TYPE_GIVE_BOLTS 13
 #define MP_STATE_TYPE_UNLOCK_LEVEL 14
+#define MP_STATE_TYPE_LEVEL_FLAG 15
 
 typedef struct {
     u32 state_type;
@@ -259,6 +261,17 @@ struct MPPacketErrorMessage {
     u16 message_length;
 };
 
+#define MP_LEVEL_FLAG_TYPE_1  1
+#define MP_LEVEL_FLAG_TYPE_2  2
+
+typedef struct {
+    u16 type;
+    u8 level;
+    u8 size;
+    u16 index;
+    u32 value;
+} MPPacketLevelFlagChanged;
+
 #pragma pack(pop)
 
 struct Packet {
@@ -283,6 +296,7 @@ struct Packet {
     static Packet* make_collected_gold_bolt_packet(int bolt_number);
     static Packet* make_unlock_item_packet(int item_id, bool equip);
     static Packet* make_unlock_level_packet(int level);
+    static Packet* make_level_flag_changed_packet(u16 type, u8 level, u8 size, u16 index, u32 value);
 };
 
 #endif

--- a/prx/rc1/multiplayer/Packet.h
+++ b/prx/rc1/multiplayer/Packet.h
@@ -345,7 +345,7 @@ struct Packet {
     static Packet* make_unlock_skillpoint_packet(u8 skillpoint);
     static Packet* make_monitored_value_changed_packet(u16 uid, u32 offset, u32 size, u8 flags, u32 old_value, u32 new_value);
     static Packet* make_level_flag_changed_packet(u16 type, u8 level, u8 size, u16 index, u32 value);
-    static Packet* make_bolt_count_changed_packet(s32 bolt_diff);
+    static Packet* make_bolt_count_changed_packet(s32 bolt_diff, u32 current_bolts);
 };
 
 #endif

--- a/prx/rc1/multiplayer/Packet.h
+++ b/prx/rc1/multiplayer/Packet.h
@@ -74,6 +74,9 @@ Here is an example of how a packet with type set to MP_PACKET_MOBY_UPDATE and no
 #define MP_PACKET_AUTH               19
 #define MP_PACKET_CREATE_USER        20
 #define MP_PACKET_ERROR_MESSAGE      21
+#define MP_PACKET_REGISTER_HYBRID_MOBY 22
+#define MP_PACKET_MONITORED_VALUE_CHANGED 23
+#define MP_PACKET_CHANGE_MOBY_VALUE 24
 #define MP_PACKET_LEVEL_FLAG_CHANGED 25
 
 #define MP_PACKET_FLAG_RPC           0x1
@@ -164,6 +167,25 @@ typedef struct {
     u32 uuid;
 } MPPacketMobyCreate;
 
+#define MP_MOBY_FLAG_FIND_BY_UUID (1 << 0)
+#define MP_MOBY_FLAG_FIND_BY_UID  (1 << 1)
+
+#define MP_MOBY_FLAG_CHANGE_ATTR (1 << 8)
+#define MP_MOBY_FLAG_CHANGE_PVAR (1 << 9)
+
+typedef struct {
+    u16 id;
+    u16 flags;
+    u16 num_values;
+} MPPacketChangeMobyValue;
+
+// Defined in Moby.h because of annoying things with including and C/C++ interop or whatever
+//typedef struct {
+//    u16 offset;
+//    u16 size;
+//    u32 value;
+//} MPPacketChangeMobyValuePayload;
+
 #define MP_MOBY_DELETE_FLAG_UUID   1
 #define MP_MOBY_DELETE_FLAG_OCLASS 2
 #define MP_MOBY_DELETE_FLAG_ALL    4
@@ -182,6 +204,29 @@ typedef struct {
     float y;
     float z;
 } MPPacketMobyCollision;
+
+typedef struct {
+    u16 moby_uid;
+    u16 n_monitored_attributes;
+    u16 n_monitored_pvars;
+} MPPacketRegisterHybridMoby;
+
+typedef struct {
+    u16 offset;
+    u16 size;
+} MPPacketMonitorValue;
+
+#define MP_MONITORED_VALUE_TYPE_ATTR 1
+#define MP_MONITORED_VALUE_TYPE_PVAR 2
+
+typedef struct {
+    u16 uid;
+    u16 offset;
+    u8 flags;
+    u8 size;
+    u32 old_value;
+    u32 new_value;
+} MPPacketMonitoredValueChanged;
 
 #define MP_STATE_TYPE_DAMAGE    1
 #define MP_STATE_TYPE_PLAYER    2
@@ -295,6 +340,7 @@ struct Packet {
     static Packet* make_game_state_changed_packet(GameState state);
     static Packet* make_collected_gold_bolt_packet(int bolt_number);
     static Packet* make_unlock_item_packet(int item_id, bool equip);
+    static Packet* make_monitored_value_changed_packet(u16 uid, u32 offset, u32 size, u8 flags, u32 old_value, u32 new_value);
     static Packet* make_unlock_level_packet(int level);
     static Packet* make_level_flag_changed_packet(u16 type, u8 level, u8 size, u16 index, u32 value);
 };

--- a/prx/rc1/multiplayer/Packet.h
+++ b/prx/rc1/multiplayer/Packet.h
@@ -345,6 +345,7 @@ struct Packet {
     static Packet* make_unlock_skillpoint_packet(u8 skillpoint);
     static Packet* make_monitored_value_changed_packet(u16 uid, u32 offset, u32 size, u8 flags, u32 old_value, u32 new_value);
     static Packet* make_level_flag_changed_packet(u16 type, u8 level, u8 size, u16 index, u32 value);
+    static Packet* make_bolt_count_changed_packet(s32 bolt_diff);
 };
 
 #endif

--- a/prx/rc1/multiplayer/Packet.h
+++ b/prx/rc1/multiplayer/Packet.h
@@ -246,6 +246,7 @@ typedef struct {
 #define MP_STATE_TYPE_UNLOCK_LEVEL 14
 #define MP_STATE_TYPE_LEVEL_FLAG 15
 #define MP_STATE_TYPE_UNLOCK_SKILLPOINT 16
+#define MP_STATE_TYPE_COMMUNICATION_FLAGS 17
 
 typedef struct {
     u16 flags;

--- a/prx/rc1/multiplayer/Packet.h
+++ b/prx/rc1/multiplayer/Packet.h
@@ -243,6 +243,7 @@ typedef struct {
 #define MP_STATE_TYPE_GIVE_BOLTS 13
 #define MP_STATE_TYPE_UNLOCK_LEVEL 14
 #define MP_STATE_TYPE_LEVEL_FLAG 15
+#define MP_STATE_TYPE_UNLOCK_SKILLPOINT 16
 
 typedef struct {
     u32 state_type;
@@ -340,8 +341,9 @@ struct Packet {
     static Packet* make_game_state_changed_packet(GameState state);
     static Packet* make_collected_gold_bolt_packet(int bolt_number);
     static Packet* make_unlock_item_packet(int item_id, bool equip);
-    static Packet* make_monitored_value_changed_packet(u16 uid, u32 offset, u32 size, u8 flags, u32 old_value, u32 new_value);
     static Packet* make_unlock_level_packet(int level);
+    static Packet* make_unlock_skillpoint_packet(u8 skillpoint);
+    static Packet* make_monitored_value_changed_packet(u16 uid, u32 offset, u32 size, u8 flags, u32 old_value, u32 new_value);
     static Packet* make_level_flag_changed_packet(u16 type, u8 level, u8 size, u16 index, u32 value);
 };
 

--- a/prx/rc1/multiplayer/Packet.h
+++ b/prx/rc1/multiplayer/Packet.h
@@ -78,6 +78,8 @@ Here is an example of how a packet with type set to MP_PACKET_MOBY_UPDATE and no
 #define MP_PACKET_MONITORED_VALUE_CHANGED 23
 #define MP_PACKET_CHANGE_MOBY_VALUE 24
 #define MP_PACKET_LEVEL_FLAG_CHANGED 25
+#define MP_PACKET_MONITOR_ADDRESS    26
+#define MP_PACKET_ADDRESS_CHANGED    27
 
 #define MP_PACKET_FLAG_RPC           0x1
 
@@ -246,13 +248,15 @@ typedef struct {
 #define MP_STATE_TYPE_UNLOCK_SKILLPOINT 16
 
 typedef struct {
-    u32 state_type;
+    u16 flags;
+    u16 state_type;
     u32 offset;
     u32 value;
 } MPPacketSetState;
 
 typedef struct {
-    u32 state_type;
+    u16 flags;
+    u16 state_type;
     u32 offset;
     float value;
 } MPPacketSetStateFloat;
@@ -318,6 +322,19 @@ typedef struct {
     u32 value;
 } MPPacketLevelFlagChanged;
 
+typedef struct {
+    u8 flags;
+    u8 size;
+    u32 address;
+} MPPacketMonitorAddress;
+
+typedef struct {
+    u32 address;
+    u16 size;
+    u32 old_value;
+    u32 new_value;
+} MPPacketAddressChanged;
+
 #pragma pack(pop)
 
 struct Packet {
@@ -345,6 +362,7 @@ struct Packet {
     static Packet* make_unlock_skillpoint_packet(u8 skillpoint);
     static Packet* make_monitored_value_changed_packet(u16 uid, u32 offset, u32 size, u8 flags, u32 old_value, u32 new_value);
     static Packet* make_level_flag_changed_packet(u16 type, u8 level, u8 size, u16 index, u32 value);
+    static Packet* make_address_changed_packet(u32 address, u16 size, u32 old_value, u32 new_value);
     static Packet* make_bolt_count_changed_packet(s32 bolt_diff, u32 current_bolts);
 };
 

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -197,6 +197,20 @@ void unlock_level(int level) {
     SHK_CALL_HOOK(_unlock_level, level);
 }
 
+SHK_HOOK(void, _unlock_skillpoint, u8);
+void _unlock_skillpoint_hook(u8 skillpoint) {
+    Client *client = Game::shared().client();
+    if (client != nullptr) {
+        Packet *packet = Packet::make_unlock_skillpoint_packet(skillpoint);
+        client->make_ack(packet, nullptr);
+        client->send(packet);
+    }
+}
+
+void unlock_skillpoint(u8 skillpoint) {
+    SHK_CALL_HOOK(_unlock_skillpoint, skillpoint);
+}
+
 void rc1_init() {
     MULTI_LOG("Multiplayer initializing.\n");
 
@@ -216,6 +230,7 @@ void rc1_init() {
     SHK_BIND_HOOK(goldBoltUpdate, goldBoltUpdateHook);
     SHK_BIND_HOOK(_unlock_item, _unlock_item_hook);
     SHK_BIND_HOOK(_unlock_level, _unlock_level_hook);
+    SHK_BIND_HOOK(_unlock_skillpoint, _unlock_skillpoint_hook);
 
     MULTI_LOG("Bound hooks\n");
 }

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -14,6 +14,7 @@
 
 bool use_custom_player_color = false;
 uint32_t custom_player_color = 0;
+EnableCommunicationsFlags enable_communication_bitmap = ENABLE_ALL;
 
 extern "C" {
 void game_tick() {
@@ -170,6 +171,10 @@ void goldBoltUpdateHook(Moby* moby) {
 // Hook the item_unlock function
 SHK_HOOK(void, _unlock_item, int, uint8_t);
 void _unlock_item_hook(int item_id, uint8_t equip) {
+    if (!(enable_communication_bitmap & ENABLE_ON_UNLOCK_ITEM)) {
+        MULTI_LOG("unlock_item communication disabled. acting autonomously.\n");
+        unlock_item(item_id, equip);
+    }
     Client *client = Game::shared().client();
     if (client != nullptr) {
         Packet *packet = Packet::make_unlock_item_packet(item_id, equip);
@@ -185,6 +190,10 @@ void unlock_item(int item_id, uint8_t equip) {
 
 SHK_HOOK(void, _unlock_level, int);
 void _unlock_level_hook(int level) {
+    if (!(enable_communication_bitmap & ENABLE_ON_UNLOCK_LEVEL)) {
+        MULTI_LOG("unlock_level communication disabled. acting autonomously.\n");
+        unlock_level(level);
+    }
     Client *client = Game::shared().client();
     if (client != nullptr) {
         Packet *packet = Packet::make_unlock_level_packet(level);

--- a/prx/rc1/rc1.h
+++ b/prx/rc1/rc1.h
@@ -38,6 +38,17 @@ typedef enum PlayerType {
     PlayerTypeHologuise = 0x3,
 } PlayerType;
 
+typedef enum EnableCommunicationsFlags {
+    ENABLE_ON_UNLOCK_ITEM     =0x00000001,
+    ENABLE_ON_UNLOCK_LEVEL    =0x00000002,
+    ENABLE_ON_PICKUP_GOLD_BOLT=0x00000004,
+    ENABLE_ON_GET_BOLTS       =0x00000008,
+
+    ENABLE_ALL=                0xffffffff
+} EnableCommunicationsFlags;
+
+extern EnableCommunicationsFlags enable_communication_bitmap;
+
 // Our global variables
 extern int game_ticks;
 

--- a/prx/rc1/rc1.h
+++ b/prx/rc1/rc1.h
@@ -31,6 +31,13 @@ typedef enum GameState {
     UnkFF = 255
 } GameState;
 
+typedef enum PlayerType {
+    PlayerTypeRatchet = 0x0,
+    PlayerTypeClank = 0x1,
+    PlayerTypeBigClank = 0x2,
+    PlayerTypeHologuise = 0x3,
+} PlayerType;
+
 // Our global variables
 extern int game_ticks;
 
@@ -46,6 +53,7 @@ SHK_FUNCTION_DEFINE_STATIC_2(0xb72b0, u64, transition_to_movement_state, u32, st
 SHK_FUNCTION_DEFINE_STATIC_0(0x164c58, void, load_destination_planet);
 SHK_FUNCTION_DEFINE_STATIC_1(0xccda0, void, toast_message, char*, message);
 SHK_FUNCTION_DEFINE_STATIC_1(0x112c20, void, unlock_planet, int, planet);
+SHK_FUNCTION_DEFINE_STATIC_4(0xdbc38, void, load_moby_model, void**, addr, int, unk0, int, unk1, short, oClass);
 
 SHK_FUNCTION_DEFINE_STATIC_2(0x151e70, void, set_spawn_point, Vec4*, position, Vec4*, rotation);
 
@@ -119,6 +127,8 @@ extern bool should_render_server_list;
 extern Moby* moby_ptr;
 extern Moby* moby_ptr_end;
 
+extern MobyClass** mclass_table;
+
 // player
 
 // The player's current bolt count.
@@ -137,8 +147,6 @@ extern int player_state;
 extern int player_state_input;
 // The player's current HP.
 extern int player_health;
-// Which player type the player is
-extern char player_type;
 
 extern Vec3 camera_pos;
 extern Vec3 camera_rot;
@@ -155,6 +163,8 @@ extern float animation_speed;
 extern int user_option_camera_left_right_movement;
 extern int user_option_camera_up_down_movement;
 extern int user_option_camera_rotation_speed;
+
+extern PlayerType player_type;
 
 void unlock_item(int item_id, uint8_t equip);
 void unlock_level(int level);

--- a/prx/rc1/rc1.h
+++ b/prx/rc1/rc1.h
@@ -168,6 +168,7 @@ extern PlayerType player_type;
 
 void unlock_item(int item_id, uint8_t equip);
 void unlock_level(int level);
+void unlock_skillpoint(u8 skillpoint);
 
 #ifdef __cplusplus
 // Pointer to Ratchet moby.


### PR DESCRIPTION
added a foundation to dynamically enable/disable actions performed by the client.
for example: bolt_count_changed_packet is a type of packet transmitted dozens of times per second, but is largely unused by the server.
These changes allow us to dynamically disable the creation of these packets.
Also implemented is the same for unlock_item and unlock_level. if these flags are disabled, the function hook calls the original function instead and does not notify the server.

Changes stable without matching server changes