### PR TITLE
implemented foundation for communication flags

### DIFF
--- a/prx/rc1/common.h
+++ b/prx/rc1/common.h
@@ -54,5 +54,15 @@ typedef enum ITEM {
     Persuader=35
 } ITEM;
 
+typedef enum EnableCommunicationsFlags {
+    ENABLE_ON_UNLOCK_ITEM     =0x00000001,
+    ENABLE_ON_UNLOCK_LEVEL    =0x00000002,
+    ENABLE_ON_PICKUP_GOLD_BOLT=0x00000004,
+    ENABLE_ON_GET_BOLTS       =0x00000008,
+
+    ENABLE_ALL=                0xffffffff
+} EnableCommunicationsFlags;
+
+extern EnableCommunicationsFlags enable_communication_bitmap;
 
 #endif

--- a/prx/rc1/multiplayer/Player.cpp
+++ b/prx/rc1/multiplayer/Player.cpp
@@ -66,7 +66,8 @@ void Player::on_tick() {
             client->send(game_state_packet);
         }
 
-        if (previous_bolt_count != player_bolts) {
+        if ((enable_communication_bitmap & ENABLE_ON_GET_BOLTS) &&
+                previous_bolt_count != player_bolts) {
             s32 bolt_diff = player_bolts - previous_bolt_count;
             client->send(Packet::make_bolt_count_changed_packet(bolt_diff, player_bolts));
             previous_bolt_count = player_bolts;

--- a/prx/rc1/multiplayer/network/GameClient.cpp
+++ b/prx/rc1/multiplayer/network/GameClient.cpp
@@ -449,6 +449,10 @@ void GameClient::update_set_state(MPPacketSetState* packet) {
             Game::shared().refresh_level_flags();
             break;
         }
+        case MP_STATE_TYPE_COMMUNICATION_FLAGS: {
+            enable_communication_bitmap = (EnableCommunicationsFlags)packet->value;
+            break;
+        }
         default: {
             Logger::error("Server asked us to set unknown state type %d", packet->state_type);
         }

--- a/prx/rc1/multiplayer/network/Packet.h
+++ b/prx/rc1/multiplayer/network/Packet.h
@@ -271,6 +271,7 @@ typedef struct {
 #define MP_STATE_TYPE_UNLOCK_LEVEL 14
 #define MP_STATE_TYPE_LEVEL_FLAG 15
 #define MP_STATE_TYPE_UNLOCK_SKILLPOINT 16
+#define MP_STATE_TYPE_COMMUNICATION_FLAGS 17
 
 typedef struct {
     u16 flags;

--- a/prx/rc1/rc1.c
+++ b/prx/rc1/rc1.c
@@ -17,6 +17,7 @@
 
 bool use_custom_player_color = false;
 uint32_t custom_player_color = 0;
+EnableCommunicationsFlags enable_communication_bitmap = ENABLE_ALL;
 
 extern "C" {
 void game_tick() {
@@ -149,6 +150,10 @@ void goldBoltUpdateHook(Moby* moby) {
 // Hook the item_unlock function
 SHK_HOOK(void, _unlock_item, int, uint8_t);
 void _unlock_item_hook(int item_id, uint8_t equip) {
+    if (!(enable_communication_bitmap & ENABLE_ON_UNLOCK_ITEM)) {
+        MULTI_LOG("unlock_item communication disabled. acting autonomously.\n");
+        unlock_item(item_id, equip);
+    }
     Client *client = Game::shared().client();
     if (client != nullptr) {
         Packet *packet = Packet::make_unlock_item_packet(item_id, equip);
@@ -164,6 +169,10 @@ void unlock_item(int item_id, uint8_t equip) {
 
 SHK_HOOK(void, _unlock_level, int);
 void _unlock_level_hook(int level) {
+    if (!(enable_communication_bitmap & ENABLE_ON_UNLOCK_LEVEL)) {
+        MULTI_LOG("unlock_level communication disabled. acting autonomously.\n");
+        unlock_level(level);
+    }
     Client *client = Game::shared().client();
     if (client != nullptr) {
         Packet *packet = Packet::make_unlock_level_packet(level);


### PR DESCRIPTION
added a foundation to dynamically enable/disable actions performed by the client.
for example: bolt_count_changed_packet is a type of packet transmitted dozens of times per second, but is largely unused by the server.
These changes allow us to dynamically disable the creation of these packets.
Also implemented is the same for unlock_item and unlock_level. if these flags are disabled, the function hook calls the original function instead and does not notify the server.

Changes stable without matching server changes